### PR TITLE
Fix build failure on Linux due to incorrect header name

### DIFF
--- a/Robus/src/portManager.c
+++ b/Robus/src/portManager.c
@@ -8,7 +8,7 @@
 #include "portManager.h"
 #include "transmission.h"
 #include "context.h"
-#include "LuosHAL.h"
+#include "luosHAL.h"
 
 /*******************************************************************************
  * Definitions


### PR DESCRIPTION
The file is called `luosHAL.h` not `LuosHAL.h`! This creates build failures on Linux! 

```
/home/runner/work/Luos/Luos/Luos/Robus/src/portManager.c:11:10: fatal error: LuosHAL.h: No such file or directory
```

As seen in https://community.platformio.org/t/building-problem-in-github-action-vm/17253. 

The files called `luosHAL.h` and is e.g. sourced from https://github.com/Luos-io/LuosHAL/blob/master/STM32F0/luosHAL.h

However commit https://github.com/Luos-io/Luos/commit/6e1564ba43443eed460ec1d594c453d39ffc2a01 broke this file from the initially correct writing to an incorrect capitalized writing.

The build of this project is only possible on Windows with its stone-age filesystem where you have case-insensitivity and `luosHAL.h` = `LuosHAL.h`, but on Linux these are different filenames and it breaks.