### PR TITLE
Fix case typo in luos_list

### DIFF
--- a/inc/luos_list.h
+++ b/inc/luos_list.h
@@ -96,7 +96,7 @@ typedef enum
     LINEAR_POSITION_LIMIT,  // min linear_position_t (m), max linear_position_t (m)
     RATIO_LIMIT,            // float(%)
     CURRENT_LIMIT,          // float(A)
-    ANGULAR_SPEED_lIMIT,    // min angular_speed_t (deg/s), max angular_speed_t (deg/s)
+    ANGULAR_SPEED_LIMIT,    // min angular_speed_t (deg/s), max angular_speed_t (deg/s)
     LINEAR_SPEED_LIMIT,     // min linear_speed_t (m/s), max linear_speed_t (m/s)
     TORQUE_LIMIT,           // max moment_t (Nm)
 


### PR DESCRIPTION
I've checked the Examples project and it seems that this macro is used nowhere, so this change shouldn't break anything.