### PR TITLE
Fix memory corruption in case of full luos_tasks occupation

### DIFF
--- a/Robus/src/msg_alloc.c
+++ b/Robus/src/msg_alloc.c
@@ -645,6 +645,8 @@ static inline void MsgAlloc_ClearLuosTask(uint16_t luos_task_id)
     if (luos_tasks_stack_id != 0)
     {
         luos_tasks_stack_id--;
+        luos_tasks[luos_tasks_stack_id].msg_pt          = 0;
+        luos_tasks[luos_tasks_stack_id].ll_container_pt = 0;
     }
     LuosHAL_SetIrqState(true);
     MsgAlloc_FindNewOldestMsg();


### PR DESCRIPTION
We discover this by receiving A LOT of message for the same service...