### PR TITLE
return number of received data on Luos_ReceiveData

### DIFF
--- a/inc/luos.h
+++ b/inc/luos.h
@@ -54,7 +54,7 @@ error_return_t Luos_SendMsg(service_t *service, msg_t *msg);
 error_return_t Luos_ReadMsg(service_t *service, msg_t **returned_msg);
 error_return_t Luos_ReadFromService(service_t *service, int16_t id, msg_t **returned_msg);
 void Luos_SendData(service_t *service, msg_t *msg, void *bin_data, uint16_t size);
-error_return_t Luos_ReceiveData(service_t *service, msg_t *msg, void *bin_data);
+int Luos_ReceiveData(service_t *service, msg_t *msg, void *bin_data);
 void Luos_SendStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);
 void Luos_SendStreamingSize(service_t *service, msg_t *msg, streaming_channel_t *stream, uint32_t max_size);
 error_return_t Luos_ReceiveStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);

--- a/test/luos/main.c
+++ b/test/luos/main.c
@@ -101,11 +101,97 @@ void unittest_Streaming_SendStreamingSize()
     }
 }
 
+void unittest_Luos_ReceiveData()
+{
+    NEW_TEST_CASE("Try to send a void message argument");
+    {
+        Reset_Context();
+        revision_t revision   = {.major = 1, .minor = 0, .build = 0};
+        service_t *service    = Luos_CreateService(0, VOID_TYPE, "Dummy_App", revision);
+        uint32_t bin_data[64] = {0xDEADBEEF};
+
+        NEW_STEP("Verify if we assert");
+        Luos_ReceiveData(NULL, 0, bin_data);
+        TEST_ASSERT_TRUE(IS_ASSERT());
+        RESET_ASSERT();
+    }
+
+    NEW_TEST_CASE("Try to send a void table argument");
+    {
+        Reset_Context();
+        revision_t revision = {.major = 1, .minor = 0, .build = 0};
+        service_t *service  = Luos_CreateService(0, VOID_TYPE, "Dummy_App", revision);
+        msg_t msg;
+        NEW_STEP("Verify if we assert");
+        Luos_ReceiveData(service, &msg, 0);
+        TEST_ASSERT_TRUE(IS_ASSERT());
+        RESET_ASSERT();
+    }
+
+    NEW_TEST_CASE("Try to send a shity service argument");
+    {
+        Reset_Context();
+        msg_t msg;
+        uint32_t bin_data[64] = {0xDEADBEEF};
+        NEW_STEP("Verify if we return an error");
+        TEST_ASSERT_EQUAL(Luos_ReceiveData(10, &msg, bin_data), -1);
+    }
+
+    NEW_TEST_CASE("Test the regular usage");
+    {
+        Reset_Context();
+        revision_t revision = {.major = 1, .minor = 0, .build = 0};
+        service_t *service  = Luos_CreateService(0, VOID_TYPE, "Dummy_App", revision);
+        msg_t msg;
+        uint8_t bin_data[256] = {0};
+
+        NEW_STEP("Verify that the first message return 0 meaning message is not completely received");
+        // Set first message
+        msg.header.size = 256;
+        memset(msg.data, 0xAA, 128);
+        TEST_ASSERT_EQUAL(Luos_ReceiveData(service, &msg, bin_data), 0);
+
+        NEW_STEP("Verify that the second message return 256 byte received");
+        msg.header.size = 128;
+        TEST_ASSERT_EQUAL(Luos_ReceiveData(service, &msg, bin_data), 256);
+
+        NEW_STEP("Check if the data is OK");
+        for (int i = 0; i < 256; i++)
+        {
+            TEST_ASSERT_EQUAL(bin_data[i], 0xAA);
+        }
+    }
+
+    NEW_TEST_CASE("Try to send a void service argument to reset the data reception");
+    {
+        Reset_Context();
+        revision_t revision = {.major = 1, .minor = 0, .build = 0};
+        service_t *service  = Luos_CreateService(0, VOID_TYPE, "Dummy_App", revision);
+        msg_t msg;
+        uint8_t bin_data[256] = {0};
+
+        NEW_STEP("Verify that the first message return 0 meaning message is not completely received");
+        // Set first message
+        msg.header.size = 256;
+        memset(msg.data, 0xAA, 128);
+        TEST_ASSERT_EQUAL(Luos_ReceiveData(service, &msg, bin_data), 0);
+
+        NEW_STEP("Verify if we return an error which mean the data reception have been reseted");
+        TEST_ASSERT_EQUAL(Luos_ReceiveData(0, &msg, bin_data), -1);
+
+        NEW_STEP("Verify that the second message return 128 byte received half of the transmitted data because we reset it in the middle");
+        msg.header.size = 128;
+        TEST_ASSERT_EQUAL(Luos_ReceiveData(service, &msg, bin_data), 128);
+    }
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
     ASSERT_ACTIVATION(1);
 
+    // Big data reception
+    UNIT_TEST_RUN(unittest_Luos_ReceiveData);
     // Streaming functions
     UNIT_TEST_RUN(unittest_Streaming_SendStreamingSize);
 


### PR DESCRIPTION
Change Luos_ReceiveData to return number of received data at the complete message reception instead of just a FAILED SUCCEED state.
Now Luos_ReceiveData return 0 if the reception is not finished.
 

<br><br />
<br><br />
               *!!! WARNING : DO NOT EDIT THE CHECKLIST BELOW !!!*
# Checklist : Merge to DEVELOP branch
## Code Quality
- [x] Each function has a header (description, inputs, outputs) 
- [x] Code is commented (particularly in hard to understand areas)
- [x] There are no new warnings that can be corrected
- [x] Commits policy is respected (constitancy commits, clear commits comments)
<br><br />
## Tests Review
- [x]  Manual Tests for new features have been *reviewed*
- [x]  Automatic Tests for new features have been *reviewed*
<br><br />
## Tests are passed the best as I can
- [x]  Non regression existing tests are *passed OK*
- [x]  New tests for new features & bug fixes are *passed OK*
<br><br />
## Documentation
- [x] Documentation is up to date
- [x] Changelog for next release is up-to-date : [fill here](https://github.com/Luos-io/Luos/pull/115)
- [x] If needed, tests are briefly described in [test repository](https://github.com/Luos-io/tests)
