### PR TITLE
Fix_dead_link_in_bootloader_doc

### DIFF
--- a/apps/documentation/docs/tools/boot.mdx
+++ b/apps/documentation/docs/tools/boot.mdx
@@ -176,7 +176,7 @@ The Luos engine's bootloader is available for the following targets:
 - STM32 F0 / F4 / G4 / L4 families
 - Microchip ATSAMD21J18
 
-Projects for each of these targets can be found in the [Luos engine's example folder](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects). You can clone this repo and use projects for your application, or use them as examples to build your own bootloader for your specific target.
+Projects for each of these targets can be found in the [Luos engine's example folder](https://github.com/Luos-io/luos_engine/tree/main/examples/projects). You can clone this repo and use projects for your application, or use them as examples to build your own bootloader for your specific target.
 
 :::info
 Examples are available for several IDEs: L4 / F4 / G4 / F0 uses platformIO, and SAMD21 uses MPLAB.
@@ -243,5 +243,5 @@ As for the bootloader, you have to modify your linker file in the application if
 You also have to add the precompilation flag `-D WITH_BOOTLOADER` to the file *platformio.ini* in your application. Your application is now ready to be flashed using a bootloader.
 
 :::info
-You can find application examples in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects).
+You can find application examples in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main/examples/projects).
 :::

--- a/apps/documentation/versioned_docs/version-2.5.0/tools/boot.mdx
+++ b/apps/documentation/versioned_docs/version-2.5.0/tools/boot.mdx
@@ -173,7 +173,7 @@ The Luos engine's bootloader is available for the following targets:
 - STM32 F0 / F4 / G4 / L4 families
 - Microchip ATSAMD21J18
 
-Projects for each of these targets can be found in the [Luos engine's example folder](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects). You can clone this repo and use projects for your application, or use them as examples to build your own bootloader for your specific target.
+Projects for each of these targets can be found in the [Luos engine's example folder](https://github.com/Luos-io/luos_engine/tree/main/examples/projects). You can clone this repo and use projects for your application, or use them as examples to build your own bootloader for your specific target.
 
 :::info
 Examples are available for several IDEs: L4 / F4 / G4 / F0 uses platformIO, and SAMD21 uses MPLAB.
@@ -239,5 +239,5 @@ As for the bootloader, you have to modify your linker file in the application if
 You also have to add the precompilation flag `-D WITH_BOOTLOADER` to the file _platformio.ini_ in your application. Your application is now ready to be flashed using a bootloader.
 
 :::info
-You can find application examples in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects).
+You can find application examples in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main/examples/projects).
 :::


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
