### PR TITLE
fix full width doc

### DIFF
--- a/apps/documentation/src/theme/MDXPage/index.js
+++ b/apps/documentation/src/theme/MDXPage/index.js
@@ -1,3 +1,4 @@
+//I swizzled the component to be able to style it full width (lines 26-28)
 import React from 'react';
 import clsx from 'clsx';
 import { PageMetadata, HtmlClassNameProvider, ThemeClassNames } from '@docusaurus/theme-common';

--- a/apps/documentation/src/theme/MDXPage/index.js
+++ b/apps/documentation/src/theme/MDXPage/index.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import clsx from 'clsx';
+import { PageMetadata, HtmlClassNameProvider, ThemeClassNames } from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import MDXContent from '@theme/MDXContent';
+import TOC from '@theme/TOC';
+import styles from './styles.module.css';
+export default function MDXPage(props) {
+  const { content: MDXPageContent } = props;
+  const {
+    metadata: { title, description, frontMatter },
+  } = MDXPageContent;
+  const { wrapperClassName, hide_table_of_contents: hideTableOfContents } = frontMatter;
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        wrapperClassName ?? ThemeClassNames.wrapper.mdxPages,
+        ThemeClassNames.page.mdxPage,
+      )}
+    >
+      <PageMetadata title={title} description={description} />
+      <Layout>
+        <main
+          className="container--fluid"
+          style={{
+            width: '100%',
+            overflow: 'hidden',
+            marginBottom: '0 !important',
+          }}
+        >
+          <div className={clsx('row', styles.mdxPageWrapper)}>
+            <div className={clsx('col', !hideTableOfContents && 'col--8')}>
+              <article>
+                <MDXContent>
+                  <MDXPageContent />
+                </MDXContent>
+              </article>
+            </div>
+            {!hideTableOfContents && MDXPageContent.toc.length > 0 && (
+              <div className="col col--2">
+                <TOC
+                  toc={MDXPageContent.toc}
+                  minHeadingLevel={frontMatter.toc_min_heading_level}
+                  maxHeadingLevel={frontMatter.toc_max_heading_level}
+                />
+              </div>
+            )}
+          </div>
+        </main>
+      </Layout>
+    </HtmlClassNameProvider>
+  );
+}

--- a/apps/documentation/src/theme/MDXPage/styles.module.css
+++ b/apps/documentation/src/theme/MDXPage/styles.module.css
@@ -1,0 +1,3 @@
+.mdxPageWrapper {
+  justify-content: center;
+}


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
