### PR TITLE
Feat/services/telemetry/add luos ip filtering

### DIFF
--- a/apps/services/pages/api/telemetry/index.ts
+++ b/apps/services/pages/api/telemetry/index.ts
@@ -87,7 +87,7 @@ export const saveTelemetry = async (req: NextApiRequest, res: NextApiResponse) =
                 f_cpu &&
                 valid(pyluos) &&
                 TelemetrySystemObject.includes(system.toUpperCase()) &&
-                macBuffer.length === 6 &&
+                macBuffer.length !== 0 &&
                 project_path
               ) {
                 insertOneResult = await db.collection<TelemetryLuosEngine>('telemetry').insertOne({

--- a/apps/services/pages/api/telemetry/index.ts
+++ b/apps/services/pages/api/telemetry/index.ts
@@ -6,7 +6,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import {
   Telemetry,
-  TelemetryFilter,
+  TelemetryFilterGitHub,
+  TelemetryFilterLuos,
   TelemetryFilterType,
   TelemetryLuosEngine,
   TelemetryPyluos,
@@ -35,11 +36,16 @@ export const saveTelemetry = async (req: NextApiRequest, res: NextApiResponse) =
 
       if (telemetry_type && system && mac && unix_time) {
         const db = (await mongoClient).db();
-        const gitHubCIDRFilter = await db.collection<TelemetryFilter>('telemetry-filters').findOne({
-          type: TelemetryFilterType.GITHUB_CIDR,
+        const gitHubCIDRFilter = await db
+          .collection<TelemetryFilterGitHub>('telemetry-filters')
+          .findOne({
+            type: TelemetryFilterType.GITHUB_CIDR,
+          });
+        const luosFilter = await db.collection<TelemetryFilterLuos>('telemetry-filter').findOne({
+          type: TelemetryFilterType.LUOS,
         });
 
-        if (gitHubCIDRFilter) {
+        if (gitHubCIDRFilter && luosFilter) {
           const dayBeforeTimestamp = new Date().getTime() - 8640000;
           const lastRefreshTimestamp = new Date(gitHubCIDRFilter.lastRefreshDate).getTime();
 
@@ -54,6 +60,7 @@ export const saveTelemetry = async (req: NextApiRequest, res: NextApiResponse) =
           }
           const isGitHubActions = ipRangeCheck(ip, gitHubCIDR);
           const isHemerra = ip === '77.199.117.170';
+          const isLuos = luosFilter.data.ips.includes(ip);
           const macBuffer = Buffer.from(mac.substring(2), 'hex');
 
           const defaultData: Telemetry = {
@@ -65,6 +72,7 @@ export const saveTelemetry = async (req: NextApiRequest, res: NextApiResponse) =
             duration: new Date().getTime() - unix_time * 1000,
             isGitHubActions,
             isHemerra,
+            isLuos,
           };
 
           let insertOneResult: InsertOneResult | null = null;

--- a/apps/services/pages/api/telemetry/index.ts
+++ b/apps/services/pages/api/telemetry/index.ts
@@ -41,7 +41,7 @@ export const saveTelemetry = async (req: NextApiRequest, res: NextApiResponse) =
           .findOne({
             type: TelemetryFilterType.GITHUB_CIDR,
           });
-        const luosFilter = await db.collection<TelemetryFilterLuos>('telemetry-filter').findOne({
+        const luosFilter = await db.collection<TelemetryFilterLuos>('telemetry-filters').findOne({
           type: TelemetryFilterType.LUOS,
         });
 

--- a/apps/services/src/types/telemetry.ts
+++ b/apps/services/src/types/telemetry.ts
@@ -31,7 +31,7 @@ export const TelemetryTypeObject = Object.keys(TelemetryType);
 export enum TelemetrySystem {
   DARWIN,
   LINUX,
-  WINDOWS,
+  WIN32,
 }
 export const TelemetrySystemObject = Object.keys(TelemetrySystem);
 

--- a/apps/services/src/types/telemetry.ts
+++ b/apps/services/src/types/telemetry.ts
@@ -2,17 +2,25 @@ import type { SemVer } from 'semver';
 
 export enum TelemetryFilterType {
   GITHUB_CIDR = 'github-cidr',
+  LUOS = 'luos',
 }
-
-export type TelemetryFilterGitHub = {
-  actions: string[];
-};
 
 export type TelemetryFilter = {
   type: TelemetryFilterType;
   lastRefreshDate: Date;
-  data: TelemetryFilterGitHub;
 };
+
+export interface TelemetryFilterGitHub extends TelemetryFilter {
+  data: {
+    actions: string[];
+  };
+}
+
+export interface TelemetryFilterLuos extends TelemetryFilter {
+  data: {
+    ips: string[];
+  };
+}
 
 export enum TelemetryType {
   luos_engine_build = 'luos_engine_build',
@@ -36,6 +44,7 @@ export type Telemetry = {
   date: Date;
   isGitHubActions: Boolean;
   isHemerra: Boolean;
+  isLuos: Boolean;
 };
 
 export interface TelemetryLuosEngine extends Telemetry {


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
