### PR TITLE
Fix Discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 <br />
 <p align="center">
-  <a aria-label="Luos Discord badge" href="https://discord.gg/luos">
+  <a aria-label="Luos Discord badge" href="https://discord.gg/luos-community-902486791658041364">
     <img src="https://img.shields.io/discord/902486791658041364?color=be99ff&label=Discord&style=flat-square">
   </a>
    <a aria-label="Luos Reddit follow badge" href="https://www.reddit.com/r/Luos">

--- a/apps/documentation/README.md
+++ b/apps/documentation/README.md
@@ -8,25 +8,31 @@
 [![](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Unleash%20electronic%20devices%20as%20microservices%20thanks%20to%20Luos&https://luos.io&via=Luos_io&hashtags=embeddedsystems,electronics,microservices,api)
 
 # Documentation
+
 ## The most for the developer​
+
 Luos provides a simple way to think your hardware products as a group of independant features. You can easily manage and share your hardware products' features with your team, external developers, or with the community. Luos is an open-source lightweight library that can be used on any MCU, leading to free and fast multi-electronic-boards products development. Choosing Luos to design a product will help you to develop, debug, validate, monitor, and manage it from the cloud.
-* → Go to the [Luos Documentation](https://docs.luos.io)
+
+- → Go to the [Luos Documentation](https://docs.luos.io)
 
 ## The most for the community​
+
 Most of the embedded developments are made from scratch. By using Luos, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-* → Join the [Luos Discord Community](https://discord.gg/luos)
-* → Join the [Luos Reddit Community](http://bit.ly/JoinLuosReddit)
+- → Join the [Luos Discord Community](https://discord.gg/luos-community-902486791658041364)
+- → Join the [Luos Reddit Community](http://bit.ly/JoinLuosReddit)
 
 ## Good practices with Luos​
+
 Luos proposes organized and effective development practices, guaranteeing development flexibility and evolutivity of your hardware product, from the idea to the maintenance of the industrialized product fleet.
 
 ## Let's do this​
+
 This section details the features of Luos technology as an embedded development platform, following these subjects:
 
-* Let's test through the [Luos get started](https://docs.luos.io/get-started/get-started/), to build, flash, run, and control your very first Luos code.
-* The [Basics of Luos](https://docs.luos.io/docs/luos-technology/basics/basics), explaining the general concepts and the project organization.
-* Definition of [Nodes](https://docs.luos.io/docs/luos-technology/node/node), and the relation between Luos and the physical world.
-* Definition of [Packages](https://docs.luos.io/docs/luos-technology/packages/package), and how to make a portable and reusable development.
-* Definition of [Services](https://docs.luos.io/docs/luos-technology/services/services), how to create and declare features in your product.
-* Definition of [Messages](https://docs.luos.io/docs/luos-technology/messages/index), when, why, and how to handle them, explaining the more advanced features of Luos.
+- Let's test through the [Luos get started](https://docs.luos.io/get-started/get-started/), to build, flash, run, and control your very first Luos code.
+- The [Basics of Luos](https://docs.luos.io/docs/luos-technology/basics/basics), explaining the general concepts and the project organization.
+- Definition of [Nodes](https://docs.luos.io/docs/luos-technology/node/node), and the relation between Luos and the physical world.
+- Definition of [Packages](https://docs.luos.io/docs/luos-technology/packages/package), and how to make a portable and reusable development.
+- Definition of [Services](https://docs.luos.io/docs/luos-technology/services/services), how to create and declare features in your product.
+- Definition of [Messages](https://docs.luos.io/docs/luos-technology/messages/index), when, why, and how to handle them, explaining the more advanced features of Luos.

--- a/apps/documentation/blog/2020-01-13-lift-banana-motors.mdx
+++ b/apps/documentation/blog/2020-01-13-lift-banana-motors.mdx
@@ -312,7 +312,7 @@ There is a wide range of reduction ratios available for gear motors. This ratio 
 
 A gear motor is a motor with a built-in reduction. This reduction allows the motor to spin slower while providing more torque. Motors alone do not have this reduction and can only spin at a certain range of speed.
 
-If you want to know more about Luos or help us with this beautiful project, <a rel="external nofollow" href="https://www.reddit.com/r/Luos/" target="_blank">follow us on Reddit</a>, <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">join our fantastic community</a>, or <a rel="external nofollow" href="https://github.com/Luos-io/Luos" target="_blank">star our Luos repository</a> on Github.
+If you want to know more about Luos or help us with this beautiful project, <a rel="external nofollow" href="https://www.reddit.com/r/Luos/" target="_blank">follow us on Reddit</a>, <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">join our fantastic community</a>, or <a rel="external nofollow" href="https://github.com/Luos-io/Luos" target="_blank">star our Luos repository</a> on Github.
 
 <h2> Now, how do I choose my motor in this mess? </h2>
 
@@ -371,7 +371,7 @@ Are you ready now to choose the suitable motor for your robot? If yes, congrats,
 
 Thank you for reading.
 
-— If you liked what you read, please clap the hell out of it and [join us on Discord!](https://discord.gg/luos)
+— If you liked what you read, please clap the hell out of it and [join us on Discord!](https://discord.gg/luos-community-902486791658041364)
 
 ![A banana](https://uploads-ssl.webflow.com/602cf5c87ad04ea98eaa99da/602fbacfe770b800bbc3e011_1*6zvW1fdWqC2K9417Hq58PA.png)
 

--- a/apps/documentation/blog/2020-02-13-dc-motor-jungle.mdx
+++ b/apps/documentation/blog/2020-02-13-dc-motor-jungle.mdx
@@ -31,7 +31,7 @@ Yes, controlling motors is complex. It's a deep jungle with savage inhabitants a
 
 In [our following posts](/2020-03-13-control-dc-motor-1.mdx), you will discover how to take control of your DC motors and make them adaptable according to your needs.
 
-If you liked what you read, please clap the hell out of it and <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">join us on Discord!</a>
+If you liked what you read, please clap the hell out of it and <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">join us on Discord!</a>
 
 Start learning how to control DC motors with this article: [How to stop being controlled by your DC motor: reverse the roles! Part 1](/2020-03-13-control-dc-motor-1.mdx)
 

--- a/apps/documentation/blog/2020-04-13-control-dc-motor-2.mdx
+++ b/apps/documentation/blog/2020-04-13-control-dc-motor-2.mdx
@@ -160,6 +160,6 @@ Thank you for reading.
 
 — If you liked what you read, please **_clap the hell out of it_** and follow us on Reddit!
 
-By the way, if you want to discover some exciting projects created with Luos and exchange with different people every day, don't hesitate to join our community: <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join us on Discord</a>
+By the way, if you want to discover some exciting projects created with Luos and exchange with different people every day, don't hesitate to join our community: <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join us on Discord</a>
 
 [Get Started with Luos](/tutorials/get-started)

--- a/apps/documentation/blog/2020-07-13-introduction-pid.mdx
+++ b/apps/documentation/blog/2020-07-13-introduction-pid.mdx
@@ -158,7 +158,7 @@ To summarize, keep in mind that a PID controller is a widely used control loop f
 
 We will dig in these [proportional](/2020-08-13-pid-p-proportional.mdx), [integral](/2020-09-13-pid-i-integral.mdx), and [derivative](/2020-10-13-pid-d-derivative.mdx) components on the following posts. We'll look at the maths behind PID control and how to adjust the three constants to get the desired behavior from our motor.
 
-PID control and many other projects are waiting for you on our blog, so don't hesitate to bookmark our content and <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">join our Discord community</a>
+PID control and many other projects are waiting for you on our blog, so don't hesitate to bookmark our content and <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">join our Discord community</a>
 
 Still on the same subject, read now the following article on the [PID: the P as in Proportional](/blog/2020-08-13-pid-p-proportional.mdx).
 

--- a/apps/documentation/blog/2020-08-13-pid-p-proportional.mdx
+++ b/apps/documentation/blog/2020-08-13-pid-p-proportional.mdx
@@ -58,7 +58,7 @@ And, if I only want a P command instead of a PID command:
 
 ![Command p formula](https://uploads-ssl.webflow.com/602cf5c87ad04ea98eaa99da/6030d498d5a2147713ebbcb1_1*eJhK8cHfHCTnV3pYxZNixA.png)
 
-Exchange on your PID control projects and meet our community directly on Discord: <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join our Discord</a>
+Exchange on your PID control projects and meet our community directly on Discord: <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join our Discord</a>
 
 Here are the simplified steps of the action of the proportional. I chose, what a surprise, the example of a DC motor which directly drives a propeller — i.e. no reduction involved. In this example **you want to control the speed** of the propeller:
 

--- a/apps/documentation/blog/2020-11-13-how-we-built-speech.mdx
+++ b/apps/documentation/blog/2020-11-13-how-we-built-speech.mdx
@@ -141,7 +141,7 @@ Progressively we were talking about the **philosophy behind Luos** more than the
 
 Even in the core of our technology, this had an impact: we replaced the name module by container, which is technically more accurate. Spoiler alert: this change will appear in <a rel="external nofollow" href="https://github.com/Luos-io/Luos" target="_blank">the next version of Luos</a>.
 
-At the same time, if you want to discover some exciting projects created with Luos, don't hesitate to join our developer community: <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join us on Discord</a>.
+At the same time, if you want to discover some exciting projects created with Luos, don't hesitate to join our developer community: <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join us on Discord</a>.
 
 <h2> Tell a story </h2>
 

--- a/apps/documentation/blog/2020-12-13-edge-embedded-skyrocket.mdx
+++ b/apps/documentation/blog/2020-12-13-edge-embedded-skyrocket.mdx
@@ -59,6 +59,6 @@ Such technology needs to be created for machines that will be produced in large 
 
 ![Robotic hand - Make it possible with Luos](https://uploads-ssl.webflow.com/602cf5c87ad04ea98eaa99da/60313103d5a21483f3ed24e8_1579688319006.png)
 
-Thanks for reading! Meet our community directly on Discord and discover thousand of unique projects → <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join our Discord</a>
+Thanks for reading! Meet our community directly on Discord and discover thousand of unique projects → <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join our Discord</a>
 
 The **Luos**' Team

--- a/apps/documentation/blog/2021-01-13-unleash-embedded.mdx
+++ b/apps/documentation/blog/2021-01-13-unleash-embedded.mdx
@@ -78,7 +78,7 @@ Electronic design becomes:
 
 In conclusion, the development of electronic devices has never evolved and is still monolithic. Companies always have to design everything from A to Z means time and skills are wasted, and risks escalate.
 
-Oh, by the way! Join our developer's community to share your knowledge and projects or discover passionating realizations: <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join us on Discord</a>
+Oh, by the way! Join our developer's community to share your knowledge and projects or discover passionating realizations: <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join us on Discord</a>
 
 At [Luos](https://www.luos.io), we believe that the best way to solve this problem is to make electronics "microservice-able."
 

--- a/apps/documentation/blog/2021-03-13-luos-raise-money.mdx
+++ b/apps/documentation/blog/2021-03-13-luos-raise-money.mdx
@@ -45,6 +45,6 @@ To continue its development, Luos is opening 10 positions in 2021, thus doubling
 
 “We have been won over by the dynamism and ambition of the LUOS team, and we are convinced that the solutions they develop will revolutionize the way of designing new electronic, maintainable and scalable products. We hope to be able to use our expertise and experience, and are proud to contribute to the development of this great startup. ” Jean-François Clédel (Chairman) and Yvan Cantou (CEO), SkalePark.
 
-Meet our community directly on Discord and discover thousand of unique projects: <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join our Discord</a>
+Meet our community directly on Discord and discover thousand of unique projects: <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join our Discord</a>
 
 [Get Started with Luos](/tutorials/get-started)

--- a/apps/documentation/blog/2021-04-13-standardized-data.mdx
+++ b/apps/documentation/blog/2021-04-13-standardized-data.mdx
@@ -65,6 +65,6 @@ Another article shows how we [think globally](/2021-06-13-think-globally.mdx) wh
 
 We live in a world where we mix and match scales and units. You can’t just use a number without a unit; 32 might be a nice warm temperature, or the freezing point of water. Without units, data is worthless, and that is something that simply cannot happen on a Luos network. Keep your mission up and running with us!
 
-Our community of experts on Luos and community members will be happy to exchange about projects and embedded systems, so don’t hesitate to <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">join us on Discord!</a>
+Our community of experts on Luos and community members will be happy to exchange about projects and embedded systems, so don’t hesitate to <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">join us on Discord!</a>
 
 [Get Started with Luos](/tutorials/get-started)

--- a/apps/documentation/blog/2021-05-13-safe-fast-lightweight.mdx
+++ b/apps/documentation/blog/2021-05-13-safe-fast-lightweight.mdx
@@ -29,7 +29,7 @@ The system controlling the structures on the wing is known as the ELAC, short fo
 
 ![Representation of computers in a plane](/assets/images/blog/computer-plane-luos.jpeg)
 
-Ladies and gentlemen, come aboard the Luos spaceship by joining the crew on Discord! A world of discovery awaits you: <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Join us on Discord</a>
+Ladies and gentlemen, come aboard the Luos spaceship by joining the crew on Discord! A world of discovery awaits you: <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Join us on Discord</a>
 
 <h2> Tiny computers </h2>
 

--- a/apps/documentation/blog/2022-02-13-semiconductor-crisis.mdx
+++ b/apps/documentation/blog/2022-02-13-semiconductor-crisis.mdx
@@ -57,7 +57,11 @@ A component problem? A chip shortage? No problem, you can change your part witho
 
 Think globally, act locally, our purpose at Luos. Our developers and community help you to conceptualize your project and avoid frustration. We are based on an **open-source** format that allows us to open our technology and access worldwide knowledge.
 
-<a rel="external nofollow" href="https://discord.gg/luos" target="_blank">
+<a
+  rel="external nofollow"
+  href="https://discord.gg/luos-community-902486791658041364"
+  target="_blank"
+>
   Join us in Discord
 </a> to exchange about projects, technology, and how Luos can work for you.
 

--- a/apps/documentation/blog/2022-03-29-biometric-security-system.mdx
+++ b/apps/documentation/blog/2022-03-29-biometric-security-system.mdx
@@ -13,13 +13,13 @@ hide_table_of_contents: false
 date: 2022-03-29T10:00
 ---
 
-Marie#9390 <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">in our Discord</a> has developed a biometric security system using Luos.
+Marie#9390 <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">in our Discord</a> has developed a biometric security system using Luos.
 
 <!--truncate-->
 
 In a quick video, find out how to reproduce this system using an Arduino or a ST Nucleo.
 
-Watch her video, see other examples <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">in our Discord</a>, or submit your project to our community!
+Watch her video, see other examples <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">in our Discord</a>, or submit your project to our community!
 
 <iframe
   width="560"

--- a/apps/documentation/blog/2022-04-15-web-app-alpha-version.mdx
+++ b/apps/documentation/blog/2022-04-15-web-app-alpha-version.mdx
@@ -121,7 +121,7 @@ It’s opening a wide variety of new possible features like:
 
 \[Spoiler Alert\] Some of them are already in development!
 
-So please take a look at our alpha version of Luos web app, stay tuned and make your suggestions by sending us a message on our <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">Discord</a> community!
+So please take a look at our alpha version of Luos web app, stay tuned and make your suggestions by sending us a message on our <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">Discord</a> community!
 
 [Discover Luos Web App](https://app.luos.io/)
 

--- a/apps/documentation/blog/2022-07-22-5-top-open-source-features-and-api-for-embedded-systems-and-edge.mdx
+++ b/apps/documentation/blog/2022-07-22-5-top-open-source-features-and-api-for-embedded-systems-and-edge.mdx
@@ -63,7 +63,7 @@ As we explain in [our documentation](/docs/tools/gate), the default behavior of 
 5. The gate sets up all network services to send their values back at the optimal frequency (optional).
 6. The gate generates formatted data with this optimal frequency and sends commands coming from the pipe.
 
-A new embedded community allows you to be informed about the embedded ecosystem and to share your knowledge with other developers: <a rel="noopener noreferrer external nofollow" href="https://discord.gg/luos" target="_blank">join us on Discord</a>
+A new embedded community allows you to be informed about the embedded ecosystem and to share your knowledge with other developers: <a rel="noopener noreferrer external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">join us on Discord</a>
 
 <h2> 3. Timestamp for embedded systems </h2>
 
@@ -99,7 +99,7 @@ Making open-source JSON API allows developers to quickly adapt the code to their
 
 The use of the JSON language makes it easy to develop new services and applications: [discover more on our documentation.](/docs/tools/api-json)
 
-**Added bonus:** find and interact with thousands of embedded and edge developers on open-source features or tools in <a rel="noopener noreferrer external nofollow" href="https://discord.gg/luos" target="_blank">our Discord community</a>
+**Added bonus:** find and interact with thousands of embedded and edge developers on open-source features or tools in <a rel="noopener noreferrer external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">our Discord community</a>
 
 <h2> Conclusion </h2>
 
@@ -111,7 +111,7 @@ We have seen in this article the main open-source features available for embedde
 
 We invite you to discover our features in our Luos engine library on GitHub: https://github.com/Luos-io/luos_engine
 
-Don't hesitate to join our [Discord server](https://discord.gg/luos) to be informed about the embedded ecosystem and share your knowledge with other developers!
+Don't hesitate to join our [Discord server](https://discord.gg/luos-community-902486791658041364) to be informed about the embedded ecosystem and share your knowledge with other developers!
 
 Discover our open-source project focused on embedded and edge devices. [Many features await you](https://www.luos.io).
 

--- a/apps/documentation/blog/2022-08-12-how-to-develop-iot-edge-and-embedded-projects-easier.mdx
+++ b/apps/documentation/blog/2022-08-12-how-to-develop-iot-edge-and-embedded-projects-easier.mdx
@@ -29,7 +29,7 @@ The dependency would lead to a limitation of possibilities.
 
 The technique should not alter or limit the imagination and the development of ideas. Whether it comes from a lack of hardware knowledge or prioritization of other objectives, the project's development should be done without reinventing the wheel or spending hours redoing existing developments, and without stress.
 
-Many examples are shared with us each month through our [Luos community](https://discord.gg/luos), but one example is currently part of the Luos team as an intern. Alexis Gorlier is a student at ESTACA (engineering school based in Paris, France) and is part of the French association ESO which develops many projects around aerospace, and especially rockets.
+Many examples are shared with us each month through our [Luos community](https://discord.gg/luos-community-902486791658041364), but one example is currently part of the Luos team as an intern. Alexis Gorlier is a student at ESTACA (engineering school based in Paris, France) and is part of the French association ESO which develops many projects around aerospace, and especially rockets.
 
 The objective is to break the current European altitude record for an amateur flight, i.e. 32km.
 
@@ -43,7 +43,7 @@ The courses given by ESTACA only give some basics on embedded systems, so we nee
 
 We have chosen to use Luos for several applications: to measure the altitude (necessary to validate the objective), to record events occurring during the flight, and last but not least, to trigger the parachute allowing the rocket to decelerate and land "almost" as a whole.
 
-Aerospace is a passion for many Luos developers and the cross-over was relevant. By the way, we can discuss my edge project directly via the Luos community on [Discord](https://discord.gg/luos).
+Aerospace is a passion for many Luos developers and the cross-over was relevant. By the way, we can discuss my edge project directly via the Luos community on [Discord](https://discord.gg/luos-community-902486791658041364).
 
 <div style={{ display: 'flex', alignItems: 'center' }}>
   <div style={{ textAlign: 'center' }}>

--- a/apps/documentation/blog/2022-08-16-ros-controlling-your-distributed-robot-using-micro-ros-and-luos.mdx
+++ b/apps/documentation/blog/2022-08-16-ros-controlling-your-distributed-robot-using-micro-ros-and-luos.mdx
@@ -91,7 +91,7 @@ ROS messages are sent and received following the publisher/subscriber method. In
 
 We need the Luos service to suscribe on every topic that we want to be received by the specific MCU. For each publisher existing in a micro-ROS node, the Luos service needs to publish the messages to the others.
 
-A few months ago, we opened a community on Discord. This Discord aims to exchange with embedded and edge developers on new project development methodologies. We want to help each other, get inspired and share together. If you are interested, <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">join the Luos community</a>!
+A few months ago, we opened a community on Discord. This Discord aims to exchange with embedded and edge developers on new project development methodologies. We want to help each other, get inspired and share together. If you are interested, <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">join the Luos community</a>!
 
 <h2>Luos middleware</h2>
 
@@ -166,7 +166,7 @@ There are some cases that you should pay attention to:
 
 This article aimed to present an analytical method for implementing a micro-ROS Luos middleware to use ROS and micro-ROS with distributed systems.
 
-You can contact us in <a rel="external nofollow" href="https://discord.gg/luos" target="_blank">our Discord community</a> if you need more information about this integration!
+You can contact us in <a rel="external nofollow" href="https://discord.gg/luos-community-902486791658041364" target="_blank">our Discord community</a> if you need more information about this integration!
 
 <a
   href="/tutorials/get-started"

--- a/apps/documentation/blog/2022-08-30-q-and-a-august-2022-first-part.mdx
+++ b/apps/documentation/blog/2022-08-30-q-and-a-august-2022-first-part.mdx
@@ -17,7 +17,7 @@ A few days ago, we held our first live Q&A session on Discord, and it was a plea
 
 If you missed it or want to discover it again, we have concatenated all your questions in this article and completed them with precise answers.
 
-If you have other questions concerning Luos, our open source project, or the embedded world, feel free to <a href="https://discord.gg/luos" rel="external nofollow">join our Discord community</a>. We are +4000 community as of right now and keep in touch with our members daily to create a strong community and an inspiring place for everyone.
+If you have other questions concerning Luos, our open source project, or the embedded world, feel free to <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">join our Discord community</a>. We are +4000 community as of right now and keep in touch with our members daily to create a strong community and an inspiring place for everyone.
 
 <!--truncate-->
 

--- a/apps/documentation/blog/2022-08-30-q-and-a-august-2022-second-part.mdx
+++ b/apps/documentation/blog/2022-08-30-q-and-a-august-2022-second-part.mdx
@@ -88,7 +88,7 @@ After that, when you have this **gate**, you will have access to all the bootloa
 
 If you have a crash on this firmware, Luos will be able to see that this firmware doesn't trend properly, and you will fall back on the bootloader. Even if you have a **complex situation** (where sometimes the applications crash and you want to update it), you can force the erasing of this application and go back to the **bootloader**.
 
-We don't have a way to block this bootloader completely right now, we have a lot of things to improve on this side, and this is something that Viktoria <a href="https://discord.gg/luos" rel="external nofollow">(Vik#1501 on Luos Discord)</a> will work on during the next few weeks.
+We don't have a way to block this bootloader completely right now, we have a lot of things to improve on this side, and this is something that Viktoria <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">(Vik#1501 on Luos Discord)</a> will work on during the next few weeks.
 
 We also have another challenge to come. Right now, Luos is an early technology. It is a state-of-the-art technology, so we have a lot of things moving around every day, and it is difficult for us to keep all the revisions compatible.
 
@@ -141,11 +141,11 @@ Eventually, our business model will rely on a SaaS model. We will provide some w
 
 <h2>Call for contributions</h2>
 
-Simon <a href="https://discord.gg/luos" rel="external nofollow">(Simon#2786 on Luos Discord)</a> recently opened a call for contributions, added on <a href="https://github.com/Luos-io/luos_engine/blob/main/CONTRIBUTING.md" rel="external nofollow">our GitHub page</a>. You can have a look at the <a href="https://github.com/Luos-io/luos_engine/issues" rel="external nofollow">issues</a>, where you will find the label `help wanted`. You will see all the issues we have right now, and you can have a look at them and contribute to them.
+Simon <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">(Simon#2786 on Luos Discord)</a> recently opened a call for contributions, added on <a href="https://github.com/Luos-io/luos_engine/blob/main/CONTRIBUTING.md" rel="external nofollow">our GitHub page</a>. You can have a look at the <a href="https://github.com/Luos-io/luos_engine/issues" rel="external nofollow">issues</a>, where you will find the label `help wanted`. You will see all the issues we have right now, and you can have a look at them and contribute to them.
 
 We also have the `good first issue` tag. This tag applied on an issue means that any user (even those who never used Luos but just want to help this open source initiative) can start they contributing journey with this kind of issue, with easy bugs and improvements. We also have a [documentation page](https://www.luos.io/docs/contribute-to-luos) to help you through your contributions.
 
-If you want to continue the discussion, feel free to <a href="https://discord.gg/luos" rel="external nofollow">join our Discord community</a>, where you will find a Help channel along with some others, and many developers waiting for you. Thank you for attending!
+If you want to continue the discussion, feel free to <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">join our Discord community</a>, where you will find a Help channel along with some others, and many developers waiting for you. Thank you for attending!
 
 <hr />
 

--- a/apps/documentation/blog/2022-09-23-create-an-amateur-space-rocket-using-luos.mdx
+++ b/apps/documentation/blog/2022-09-23-create-an-amateur-space-rocket-using-luos.mdx
@@ -120,7 +120,7 @@ It also permits us to easily add redundancy to our system, as we will be able to
   />
 </div>
 
-Finally, Luos is quite easy to use because the [examples](/tutorials/trainings) given on the Luos website easily allow to understand how it works, and the Luos's developers are <a href="https://discord.gg/luos" rel="external nofollow">available on Discord</a> to help the community when a problem is encountered.
+Finally, Luos is quite easy to use because the [examples](/tutorials/trainings) given on the Luos website easily allow to understand how it works, and the Luos's developers are <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">available on Discord</a> to help the community when a problem is encountered.
 
 Considering all the properties I listed above, Luos is an answer to all of this project's issues.
 
@@ -250,7 +250,7 @@ This service can be reused for every system that needs to activate an interrupte
 As I said in the first part, there are still some years of development left for this project.
 
 If you are interested in this project and want to see how it evolves, you can check our association news on <a href="https://www.instagram.com/estaca_space_odyssey/?hl=fr" rel="external nofollow">Instagram</a>.
-There might as well be other publications in the future on that project, you can <a href="https://discord.gg/luos" rel="external nofollow">join the Luos community</a> to discuss about it!
+There might as well be other publications in the future on that project, you can <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">join the Luos community</a> to discuss about it!
 
 I made a video to present this project as well:
 

--- a/apps/documentation/blog/2022-10-11-q-and-a-october-2022.mdx
+++ b/apps/documentation/blog/2022-10-11-q-and-a-october-2022.mdx
@@ -19,7 +19,7 @@ Last week we organized a <a href="https://www.youtube.com/watch?v=I2dsTqB-7Jk" r
 
 If you were not able to attend or if you want to go back to the information that was discussed during the Livestream this blog post is a resume of everything.
 
-If you have other questions concerning Luos, our open-source project, or the embedded world, feel free to <a href="https://discord.gg/luos" rel="external nofollow"> join our Discord community</a>. We are a +6000 member community as of right now and keep in touch with our members daily to create a strong community and an inspiring place for everyone.
+If you have other questions concerning Luos, our open-source project, or the embedded world, feel free to <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow"> join our Discord community</a>. We are a +6000 member community as of right now and keep in touch with our members daily to create a strong community and an inspiring place for everyone.
 
 <h2>Where did the idea of creating Luos come from?</h2>
 
@@ -116,7 +116,7 @@ We also have flags for **easy-to-do contributions** and some more advanced contr
 
 We also have a page on our documentation that explains the process more in detail. **[Contribute to Luos](/docs/contribute-to-luos)**. If you have any questions about it, or any idea about how to contribute to Luos, feel free to join us on discord and directly ask us on the server.
 
-We have recently had a **big growth** on our <a href="https://discord.gg/luos" rel="external nofollow">Discord server</a> which we are really proud of, so **thanks to all of you**.
+We have recently had a **big growth** on our <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">Discord server</a> which we are really proud of, so **thanks to all of you**.
 
 <hr />
 

--- a/apps/documentation/blog/2022-11-07-a-flexible-embedded-bootloader.mdx
+++ b/apps/documentation/blog/2022-11-07-a-flexible-embedded-bootloader.mdx
@@ -67,7 +67,7 @@ Finally, in some cases, this method requires developing a specific bootloader fo
   each of them
 </h2>
 
-Luos has developed a specific bootloader based on their different experiences and which meet all the <a href="https://discord.gg/luos" rel="external nofollow">community needs</a>.
+Luos has developed a specific bootloader based on their different experiences and which meet all the <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">community needs</a>.
 
 But what exactly does the embedded community need?
 

--- a/apps/documentation/blog/2023-01-03-luos-native.mdx
+++ b/apps/documentation/blog/2023-01-03-luos-native.mdx
@@ -107,7 +107,7 @@ To test Luos without hardware, select the No-board folder in the _[Get Started](
 
 You can also open an issue on GitHub and <a href="https://github.com/Luos-io/luos_engine" rel="external nofollow">contribute to the Luos repository</a>.
 
-Of course, if you need any help, you can <a href="https://discord.gg/luos" rel="external nofollow">join our Discord server</a>.
+Of course, if you need any help, you can <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">join our Discord server</a>.
 
 Thank you for reading and we hope you enjoy the new Luos Native feature!
 

--- a/apps/documentation/blog/2023-01-13-how-do-we-build-our-embedded-developer-community-with-discord.mdx
+++ b/apps/documentation/blog/2023-01-13-how-do-we-build-our-embedded-developer-community-with-discord.mdx
@@ -181,11 +181,11 @@ Before using the tool, we had taken the approach to focus solely on SEO. We, at 
 
 <h2>Conclusion</h2>
 
-With some of the actions we have listed so far and others you will see if you join our <a href="https://discord.gg/luos" rel="external nofollow">Discord</a>, we have managed to keep the community growing by 50% every month.
+With some of the actions we have listed so far and others you will see if you join our <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">Discord</a>, we have managed to keep the community growing by 50% every month.
 
 Due to the popularity and commitment of our members, we are now working with our best members, called Helpers. These helpers are fully involved in the project. It is now up to us to involve them even more in the team. We hope that these few lines and this toolbox will help you develop a community that supports and contributes to your project. A few days ago we reached the 11,000 members mark, don't hesitate to contact us to share your successes as well!
 
-To see all our tips in action, we invite you to join our <a href="https://discord.gg/luos" rel="external nofollow">Discord server</a>.
+To see all our tips in action, we invite you to join our <a href="https://discord.gg/luos-community-902486791658041364" rel="external nofollow">Discord server</a>.
 
 <a
   href="/tutorials/get-started"

--- a/apps/documentation/docs/compatibility/ecosystem.mdx
+++ b/apps/documentation/docs/compatibility/ecosystem.mdx
@@ -72,7 +72,7 @@ For example, a node with the version 1.3.0 and a node with the version 1.2.0 are
 Despite this compatibility, some bugs may exist if you use different minor versions of a same major version. We advise you to use the same version of Luos engine in every nodes of a network.
 :::
 
-If you encounter a bug or a compatibility issue, please contact us through the <a href="https://discord.gg/luos" target="_blank">**Luos Community on Discord<IconExternalLink width="10"></IconExternalLink>**</a>.
+If you encounter a bug or a compatibility issue, please contact us through the <a href="https://discord.gg/luos-community-902486791658041364" target="_blank">**Luos Community on Discord<IconExternalLink width="10"></IconExternalLink>**</a>.
 
 ## Where to download Luos
 

--- a/apps/documentation/docs/contribute-to-luos.mdx
+++ b/apps/documentation/docs/contribute-to-luos.mdx
@@ -40,7 +40,7 @@ But you will also be able to contribute by commenting in existing issues by brin
 **Before creating a new issue:**
 
 - [ ] Verify what you want to talk about: if you are reporting a bug, are you sure it is an actual bug and not a particular way of using Luos that doesn't suite you in a particular case?
-- [ ] If you want to request a feature, did you check that there is no way to do what you want to do? Do not hesitate to search in the <a href="https://www.luos.io/docs/luos-technology" target ="_blank">documentation</a> first and <a href="https://discord.gg/luos" target ="_blank">ask questions on the Discord</a> before to rush in the creation of a new issue.
+- [ ] If you want to request a feature, did you check that there is no way to do what you want to do? Do not hesitate to search in the <a href="https://www.luos.io/docs/luos-technology" target ="_blank">documentation</a> first and <a href="https://discord.gg/luos-community-902486791658041364" target ="_blank">ask questions on the Discord</a> before to rush in the creation of a new issue.
 - [ ] Ensure that no other issue has been opened before on the same subject, to prevent any duplicate. You can [use the search bar](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) with various filters.
 
 **When opening a new issue:**

--- a/apps/documentation/docs/luos-technology/index.mdx
+++ b/apps/documentation/docs/luos-technology/index.mdx
@@ -21,10 +21,10 @@ Luos engine is an <a href="https://github.com/Luos-io/luos_engine" target="_blan
 
 Most of the embedded developments are made from scratch. By using Luos engine, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos engine [services](./services/index.mdx) will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-We created a community on <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Discord</a> to create exchanges among developers from around the world. This allows anyone to share their projects, needs and ideas for developing edge and embedded projects. Everyone is welcome to join:
+We created a community on <a href="https://discord.gg/luos-community-902486791658041364" target="_blank" rel="external nofollow">Discord</a> to create exchanges among developers from around the world. This allows anyone to share their projects, needs and ideas for developing edge and embedded projects. Everyone is welcome to join:
 
 <a
-  href="https://discord.gg/luos"
+  href="https://discord.gg/luos-community-902486791658041364"
   target="_blank"
   rel="external nofollow"
   className="pagination-nav__link"

--- a/apps/documentation/docs/tools/monitoring.mdx
+++ b/apps/documentation/docs/tools/monitoring.mdx
@@ -103,7 +103,7 @@ and then send the following command:
 ```
 
 :::info
-If you need more information on how to debug your application using a sniffer, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos).
+If you need more information on how to debug your application using a sniffer, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos-community-902486791658041364).
 :::
 
 ## Inspector
@@ -135,5 +135,5 @@ The inspector does not receive the messages that regard the detection, as it is 
 :::
 
 :::info
-If you need more information on how to debug your application using the inspector, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos).
+If you need more information on how to debug your application using the inspector, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos-community-902486791658041364).
 :::

--- a/apps/documentation/docusaurus.config.js
+++ b/apps/documentation/docusaurus.config.js
@@ -137,7 +137,7 @@ module.exports = {
           position: 'right',
           items: [
             {
-              to: 'https://discord.gg/luos',
+              to: 'https://discord.gg/luos-community-902486791658041364',
               label: 'Discord',
             },
             {
@@ -176,7 +176,7 @@ module.exports = {
           items: [
             {
               label: 'Discord',
-              href: 'https://discord.gg/luos',
+              href: 'https://discord.gg/luos-community-902486791658041364',
             },
             {
               label: 'Reddit',

--- a/apps/documentation/faq/999.add-issue.mdx
+++ b/apps/documentation/faq/999.add-issue.mdx
@@ -10,5 +10,5 @@ import IconExternalLink from '@theme/Icon/ExternalLink';
 If you encounter an issue that should appear in the FAQ, you can describe it as precisely as possible by:
 
 - Adding an issue on <a href="https://github.com/luos-io/luos_engine/issues/new/choose" target="_blank" rel="external nofollow">Luos GitHub page<IconExternalLink width="10"></IconExternalLink></a>.
-- Chatting with us in the <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Luos Discord community<IconExternalLink width="10"></IconExternalLink></a>.
+- Chatting with us in the <a href="https://discord.gg/luos-community-902486791658041364" target="_blank" rel="external nofollow">Luos Discord community<IconExternalLink width="10"></IconExternalLink></a>.
 - Asking your question in the <a href="https://www.reddit.com/r/Luos/" target="_blank" rel="external nofollow">Luos Reddit community<IconExternalLink width="10"></IconExternalLink></a>.

--- a/apps/documentation/src/components/ContactUs.js
+++ b/apps/documentation/src/components/ContactUs.js
@@ -9,7 +9,7 @@ export const ContactUs = (props) => {
   return (
     <div className="contactUs">
       A feedback? Let's discuss on&nbsp;
-      <a href="https://discord.gg/luos" target="_blank">
+      <a href="https://discord.gg/luos-community-902486791658041364" target="_blank">
         Discord
       </a>
       &nbsp;|&nbsp;

--- a/apps/documentation/vercel.json
+++ b/apps/documentation/vercel.json
@@ -390,7 +390,7 @@
     },
     {
       "source": "/support",
-      "destination": "https://discord.gg/luos",
+      "destination": "https://discord.gg/luos-community-902486791658041364",
       "statusCode": 301
     },
     {
@@ -420,11 +420,11 @@
     },
     {
       "source": "/us/community",
-      "destination": "https://discord.gg/luos"
+      "destination": "https://discord.gg/luos-community-902486791658041364"
     },
     {
       "source": "/us/contact",
-      "destination": "https://discord.gg/luos"
+      "destination": "https://discord.gg/luos-community-902486791658041364"
     },
     {
       "source": "/us/pricing",
@@ -438,7 +438,7 @@
     },
     {
       "source": "/support",
-      "destination": "https://discord.gg/luos",
+      "destination": "https://discord.gg/luos-community-902486791658041364",
       "statusCode": 301
     },
     {

--- a/apps/documentation/versioned_docs/version-2.9.0/compatibility/ecosystem.mdx
+++ b/apps/documentation/versioned_docs/version-2.9.0/compatibility/ecosystem.mdx
@@ -72,7 +72,7 @@ For example, a node with the version 1.3.0 and a node with the version 1.2.0 are
 Despite this compatibility, some bugs may exist if you use different minor versions of a same major version. We advise you to use the same version of Luos engine in every nodes of a network.
 :::
 
-If you encounter a bug or a compatibility issue, please contact us through the <a href="https://discord.gg/luos" target="_blank">**Luos Community on Discord<IconExternalLink width="10"></IconExternalLink>**</a>.
+If you encounter a bug or a compatibility issue, please contact us through the <a href="https://discord.gg/luos-community-902486791658041364" target="_blank">**Luos Community on Discord<IconExternalLink width="10"></IconExternalLink>**</a>.
 
 ## Where to download Luos
 

--- a/apps/documentation/versioned_docs/version-2.9.0/contribute-to-luos.mdx
+++ b/apps/documentation/versioned_docs/version-2.9.0/contribute-to-luos.mdx
@@ -40,7 +40,7 @@ But you will also be able to contribute by commenting in existing issues by brin
 **Before creating a new issue:**
 
 - [ ] Verify what you want to talk about: if you are reporting a bug, are you sure it is an actual bug and not a particular way of using Luos that doesn't suite you in a particular case?
-- [ ] If you want to request a feature, did you check that there is no way to do what you want to do? Do not hesitate to search in the <a href="https://www.luos.io/docs/luos-technology" target ="_blank">documentation</a> first and <a href="https://discord.gg/luos" target ="_blank">ask questions on the Discord</a> before to rush in the creation of a new issue.
+- [ ] If you want to request a feature, did you check that there is no way to do what you want to do? Do not hesitate to search in the <a href="https://www.luos.io/docs/luos-technology" target ="_blank">documentation</a> first and <a href="https://discord.gg/luos-community-902486791658041364" target ="_blank">ask questions on the Discord</a> before to rush in the creation of a new issue.
 - [ ] Ensure that no other issue has been opened before on the same subject, to prevent any duplicate. You can [use the search bar](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) with various filters.
 
 **When opening a new issue:**

--- a/apps/documentation/versioned_docs/version-2.9.0/luos-technology/index.mdx
+++ b/apps/documentation/versioned_docs/version-2.9.0/luos-technology/index.mdx
@@ -21,10 +21,10 @@ Luos engine is an <a href="https://github.com/Luos-io/luos_engine" target="_blan
 
 Most of the embedded developments are made from scratch. By using Luos engine, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos engine [services](./services/index.mdx) will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-We created a community on <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Discord</a> to create exchanges among developers from around the world. This allows anyone to share their projects, needs and ideas for developing edge and embedded projects. Everyone is welcome to join:
+We created a community on <a href="https://discord.gg/luos-community-902486791658041364" target="_blank" rel="external nofollow">Discord</a> to create exchanges among developers from around the world. This allows anyone to share their projects, needs and ideas for developing edge and embedded projects. Everyone is welcome to join:
 
 <a
-  href="https://discord.gg/luos"
+  href="https://discord.gg/luos-community-902486791658041364"
   target="_blank"
   rel="external nofollow"
   className="pagination-nav__link"

--- a/apps/documentation/versioned_docs/version-2.9.0/tools/monitoring.mdx
+++ b/apps/documentation/versioned_docs/version-2.9.0/tools/monitoring.mdx
@@ -103,7 +103,7 @@ and then send the following command:
 ```
 
 :::info
-If you need more information on how to debug your application using a sniffer, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos).
+If you need more information on how to debug your application using a sniffer, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos-community-902486791658041364).
 :::
 
 ## Inspector
@@ -135,5 +135,5 @@ The inspector does not receive the messages that regard the detection, as it is 
 :::
 
 :::info
-If you need more information on how to debug your application using the inspector, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos).
+If you need more information on how to debug your application using the inspector, contact us at [hello@luos.io](mailto:hello@luos.io) or connect to the [Luos community Discord](https://discord.gg/luos-community-902486791658041364).
 :::

--- a/apps/landing/pages/roadmap/index.tsx
+++ b/apps/landing/pages/roadmap/index.tsx
@@ -87,7 +87,11 @@ export const Roadmap = () => {
           </p>
 
           <Box textAlign="center">
-            <Button href="https://discord.gg/luos" variant="outlined" className={styles.btn}>
+            <Button
+              href="https://discord.gg/luos-community-902486791658041364"
+              variant="outlined"
+              className={styles.btn}
+            >
               Join the community
             </Button>
           </Box>
@@ -207,7 +211,11 @@ export const Roadmap = () => {
             </TabPanel>
           </Box>
           <Box textAlign="center">
-            <Button href="https://discord.gg/luos" className={styles.btn} variant="outlined">
+            <Button
+              href="https://discord.gg/luos-community-902486791658041364"
+              className={styles.btn}
+              variant="outlined"
+            >
               Join the community
             </Button>
           </Box>

--- a/apps/landing/src/components/benefits/index.tsx
+++ b/apps/landing/src/components/benefits/index.tsx
@@ -95,7 +95,7 @@ export const Benefits = () => {
               className={styles.listLink}
               alignItems="flex-start"
               component={Link}
-              href="https://discord.gg/luos"
+              href="https://discord.gg/luos-community-902486791658041364"
               rel="external nofollow"
             >
               <ListItemAvatar className={styles.listIcon}>

--- a/apps/landing/src/components/introduction/index.tsx
+++ b/apps/landing/src/components/introduction/index.tsx
@@ -72,7 +72,7 @@ const Introduction = () => {
                 <Button
                   variant="contained"
                   className={styles.whiteBtn}
-                  href="https://discord.gg/luos"
+                  href="https://discord.gg/luos-community-902486791658041364"
                   rel="nofollow"
                 >
                   Join the community

--- a/apps/landing/src/components/layout/index.tsx
+++ b/apps/landing/src/components/layout/index.tsx
@@ -95,7 +95,7 @@ export const Layout = ({ children }: LayoutProps) => {
               {
                 name: 'Discord',
                 type: NavbarItemTypes.LINK,
-                href: 'https://discord.gg/luos',
+                href: 'https://discord.gg/luos-community-902486791658041364',
               },
               {
                 name: 'Reddit',

--- a/apps/landing/src/components/prefooter/index.tsx
+++ b/apps/landing/src/components/prefooter/index.tsx
@@ -34,7 +34,7 @@ const Prefooter = () => (
           <Button
             variant="contained"
             className={styles.whiteBtn}
-            href="https://discord.gg/luos"
+            href="https://discord.gg/luos-community-902486791658041364"
             rel="nofollow"
           >
             Join the community

--- a/apps/services/pages/index.tsx
+++ b/apps/services/pages/index.tsx
@@ -170,7 +170,7 @@ export const Home = ({ game }: InferGetServerSidePropsType<typeof getServerSideP
                 image={Community}
                 title="Community"
                 description="Join a community of developers, project managers, and makers revolving around Luos."
-                link="https://discord.gg/luos"
+                link="https://discord.gg/luos-community-902486791658041364"
                 blank={true}
                 action={communityButton}
               />

--- a/apps/services/src/components/layout/footer/footer.tsx
+++ b/apps/services/src/components/layout/footer/footer.tsx
@@ -23,7 +23,7 @@ export const Footer = () => {
       items: [
         {
           label: 'Discord',
-          to: 'https://discord.gg/luos',
+          to: 'https://discord.gg/luos-community-902486791658041364',
         },
         {
           label: 'Reddit',
@@ -52,7 +52,10 @@ export const Footer = () => {
       <div className={styles.container}>
         <div className={styles.joinUsContainer}>
           <h3>Join us on</h3>
-          <a href="https://discord.gg/luos" style={{ marginRight: '15px', marginLeft: '15px' }}>
+          <a
+            href="https://discord.gg/luos-community-902486791658041364"
+            style={{ marginRight: '15px', marginLeft: '15px' }}
+          >
             <Image
               className={styles.rsLogo}
               width={32}

--- a/apps/services/src/components/layout/header/header.tsx
+++ b/apps/services/src/components/layout/header/header.tsx
@@ -127,7 +127,7 @@ export const ButtonAppBar = ({ toogleLight }: HeaderProps) => {
             >
               <MenuItem onClick={popupStateCom.close} className={Styles.dropdownLink}>
                 <Link
-                  href="https://discord.gg/luos"
+                  href="https://discord.gg/luos-community-902486791658041364"
                   target={'_blank'}
                   className={Styles.dropdownLink}
                 >


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
