### PR TITLE
[Header] Add GitHub link on the button

### DIFF
--- a/packages/ui/src/header/index.tsx
+++ b/packages/ui/src/header/index.tsx
@@ -166,7 +166,7 @@ export const Header = (props: HeaderProps) => {
               className={clsx(styles.headerItemsRight, styles.navbar)}
             >
               {navbarElement}
-              <IconButton>
+              <IconButton href='https://github.com/luos-io'>
                 <GitHubIcon />
               </IconButton>
               {props.enableLightingButton && (
@@ -204,7 +204,7 @@ export const Header = (props: HeaderProps) => {
         >
           <Box component={'nav'} className={clsx(styles.navbarMobile)}>
             {navbarElement}
-            <IconButton>
+            <IconButton href={'https://github.com/luos-io'}>
               <GitHubIcon />
             </IconButton>
             {props.enableLightingButton && (


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
