### PR TITLE
Rc 3.1.0

### DIFF
--- a/apps/documentation/docs/integrations/pyluos.mdx
+++ b/apps/documentation/docs/integrations/pyluos.mdx
@@ -347,3 +347,27 @@ device.button_mod.type
 
 device.rgb_led_mod.rename("myLED")
 ```
+
+## Custom services
+
+Pyluos allows you to work with custom services. You can create your own from scratch or override an existing one. To do that, you need to provide Pyluos with your custom service type object before creating the `Device` object.
+
+### Creating a custom service
+
+The best way to create a custom service is to copy and paste an existing one from the [service folder of pyluos](https://github.com/Luos-io/Pyluos/tree/master/pyluos/services) and modify it. An example of managing a custom Pyluos service is available in the [luos_engine product example](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/product).
+
+### Mapping you custom service into pyluos
+
+Once you have created your custom service, you need to map it into Pyluos. To do that, create a custom service type object and provide it to Pyluos before creating the `Device` object.
+
+```python
+from pyluos import Device, map_custom_service
+
+# Import the custom service and map it
+sys.path.append('$PATH_TO_YOUR_FOLDER_CONTAINING_YOUR_OBJECT_FILE')
+from point_2D import Point_2D
+map_custom_service("point_2D", Point_2D)
+
+# Now you can create your device, and your custom service will be used
+device = Device('address of the device')
+```

--- a/apps/documentation/docs/luos-technology/basics/organization.mdx
+++ b/apps/documentation/docs/luos-technology/basics/organization.mdx
@@ -9,17 +9,21 @@ import Image from '@site/src/components/Image';
 
 Because Luos engine allows you to manage your features as sharable blocks of code, we organized the code in a specific way allowing to easily integrate and share packages from your projects with as little friction as possible.
 
+:::note
+You can find a complete product example with custom service types, custom messages command as well as all the customization to easily take control of your device in the [product example of Luos_engine](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/product).
+:::
+
 ### Luos engine's levels
 
 Different levels on the code projects are defined, corresponding to the different levels of information needed across your entire product.
 
-|  Level  |                                                                            Description                                                                            |
-| :-----: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| Product | This is the place where you will have the configurations and information intended for all your nodes.                                                             |
-|  Node   |                 This is the executable's code. This is your actual Eclipse, PlatformIO, IAR, or any other project.                                                |
-| Package |                       A sharable folder containing code files managing Services or Phy.                                                                           |
-| Service |                       A Luos services can be drivers or apps. Each service manage a specific feature of the product.                                              |
-| Phy     |                       A Phy is a network code allowing Luos to access other nodes and services.                                                                   |
+|  Level  |                                              Description                                              |
+| :-----: | :---------------------------------------------------------------------------------------------------: |
+| Product | This is the place where you will have the configurations and information intended for all your nodes. |
+|  Node   |  This is the executable's code. This is your actual Eclipse, PlatformIO, IAR, or any other project.   |
+| Package |                   A sharable folder containing code files managing Services or Phy.                   |
+| Service |    A Luos services can be drivers or apps. Each service manage a specific feature of the product.     |
+|   Phy   |               A Phy is a network code allowing Luos to access other nodes and services.               |
 
 ```mermaid
 graph TB

--- a/apps/documentation/docs/luos-technology/messages/auto-update.mdx
+++ b/apps/documentation/docs/luos-technology/messages/auto-update.mdx
@@ -24,10 +24,6 @@ msg.header.cmd = UPDATE_PUB;
 Luos_SendMsg(app, &msg);
 ```
 
-:::info
-Services can handle only one time-triggered target, 2 services of the same network can't ask a time-triggered value from the same service.
-:::
-
 :::caution
 To prevent any ID movement, auto-update configuration is reset on all services on each detection (see [Routing table page](../node/topology) for more information).
 :::

--- a/apps/documentation/docs/luos-technology/messages/command.mdx
+++ b/apps/documentation/docs/luos-technology/messages/command.mdx
@@ -40,7 +40,7 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | TEMPERATURE |               temperature_t (°C)               |
 |    TIME     |              time Second (float)               |
 |    FORCE    |               force_t (Newton N)               |
-|   MOMENT    |          moment_t (Newton meter N.m)           |
+|   TORQUE    |          torque_t (Newton meter N.m)           |
 |   CONTROL   |         control_mode (control_mode_t)          |
 
 ### Configuration commands
@@ -84,7 +84,7 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 |     CURRENT_LIMIT      |                          float(A)                          |
 |  ANGULAR_SPEED_LIMIT   |  min angular_speed_t (deg/s), max angular_speed_t (deg/s)  |
 |   LINEAR_SPEED_LIMIT   |     min linear_speed_t (m/s), max linear_speed_t (m/s)     |
-|      TORQUE_LIMIT      |                     max moment_t (Nm)                      |
+|      TORQUE_LIMIT      |                     max torque_t (Nm)                      |
 |   TEMPERATURE_LIMIT    |                   max temperature_t (°C)                   |
 
 ### Specific register

--- a/apps/documentation/docs/luos-technology/messages/msg_api_ref.mdx
+++ b/apps/documentation/docs/luos-technology/messages/msg_api_ref.mdx
@@ -23,6 +23,7 @@ By writing services code you will have the opportunity to use the Luos engine's 
 | :-------------------------------------------------: | :---------------------------------------------------------------------------: | :--------------: |
 |                 Read a Luos message                 |           `Luos_ReadMsg(service_t *service, msg_t *msg_to_write);`            | `error_return_t` |
 | Read a Luos message comming from a specific service | `Luos_ReadFromService(service_t *service, uint16_t id, msg_t *msg_to_write);` | `error_return_t` |
+|     Read a Luos message with a specific command     |   `Luos_ReadFromCmd(service_t *service, uint16_t id, msg_t *msg_to_write);`   | `error_return_t` |
 |        Get the number of available messages         |                         `Luos_NbrAvailableMsg(void);`                         |    `uint16_t`    |
 
 ## Luos timestamp management functions

--- a/apps/documentation/docs/luos-technology/messages/msg_api_ref.mdx
+++ b/apps/documentation/docs/luos-technology/messages/msg_api_ref.mdx
@@ -11,55 +11,60 @@ By writing services code you will have the opportunity to use the Luos engine's 
 
 ## Luos messages management functions
 
-|                        Description                      |                                       Function                                               |               Return                |
-| :-----------------------------------------------:       | :------------------------------------------------------------------------------------------: | :---------------------------------: |
-|    Remove all pending massages                          | `Luos_Flush(void);`                                                                          |             `void`                  |
-|                    Send a Luos message                  |                    `Luos_SendMsg(service_t *service, msg_t *msg);`                           |          `error_return_t`           |
-| Allow to know if all TX messages have been processed    |                    `Luos_TxComplete(void);`                                                  |          `error_return_t`           |
+|                     Description                      |                    Function                     |      Return      |
+| :--------------------------------------------------: | :---------------------------------------------: | :--------------: |
+|             Remove all pending massages              |               `Luos_Flush(void);`               |      `void`      |
+|                 Send a Luos message                  | `Luos_SendMsg(service_t *service, msg_t *msg);` | `error_return_t` |
+| Allow to know if all TX messages have been processed |            `Luos_TxComplete(void);`             | `error_return_t` |
 
 ## Luos polling message management functions (please consider using callback instead)
-|                        Description                  |                                       Function                                               |               Return                |
-| :-----------------------------------------------:   | :------------------------------------------------------------------------------------------: | :---------------------------------: |
-|                    Read a Luos message              |               `Luos_ReadMsg(service_t *service, msg_t *msg_to_write);`                       |          `error_return_t`           |
-| Read a Luos message comming from a specific service | `Luos_ReadFromService(service_t *service, uint16_t id, msg_t *msg_to_write);`                |          `error_return_t`           |
-|          Get the number of available messages       | `Luos_NbrAvailableMsg(void);`                                                                |          `uint16_t`                 |
+
+|                     Description                     |                                   Function                                    |      Return      |
+| :-------------------------------------------------: | :---------------------------------------------------------------------------: | :--------------: |
+|                 Read a Luos message                 |           `Luos_ReadMsg(service_t *service, msg_t *msg_to_write);`            | `error_return_t` |
+| Read a Luos message comming from a specific service | `Luos_ReadFromService(service_t *service, uint16_t id, msg_t *msg_to_write);` | `error_return_t` |
+|        Get the number of available messages         |                         `Luos_NbrAvailableMsg(void);`                         |    `uint16_t`    |
 
 ## Luos timestamp management functions
-|                        Description                                 |                                       Function                                               |               Return                |
-| :--------------------------------------------------------:         | :------------------------------------------------------------------------------------------: | :---------------------------------: |
-|              Get the current timestamp                             |    `Luos_Timestamp(void);`                                                                   |          `time_luos_t`              |
-|              Return true if the given message is timestamped       |    `Luos_IsMsgTimstamped(const msg_t *msg);`                                                 |          `bool`                     |
-|              Extract the timestamp from a message                  |    `Luos_GetMsgTimestamp(msg_t *msg);`                                                       |          `time_luos_t`              |
-|              Send a timestamped Luos message                       |    `Luos_SendTimestampMsg(service_t *service, msg_t *msg, time_luos_t timestamp);`           |          `error_return_t`           |
 
+|                   Description                   |                                    Function                                     |      Return      |
+| :---------------------------------------------: | :-----------------------------------------------------------------------------: | :--------------: |
+|            Get the current timestamp            |                             `Luos_Timestamp(void);`                             |  `time_luos_t`   |
+| Return true if the given message is timestamped |                    `Luos_IsMsgTimstamped(const msg_t *msg);`                    |      `bool`      |
+|      Extract the timestamp from a message       |                       `Luos_GetMsgTimestamp(msg_t *msg);`                       |  `time_luos_t`   |
+|         Send a timestamped Luos message         | `Luos_SendTimestampMsg(service_t *service, msg_t *msg, time_luos_t timestamp);` | `error_return_t` |
 
 ## Luos big data management functions
-|                        Description                                 |                                       Function                                               |               Return                |
-| :--------------------------------------------------------:         | :------------------------------------------------------------------------------------------: | :---------------------------------: |
-|      Send the remaining data in case of long messages              |    `Luos_SendData(service_t *service, msg_t *msg, void *bin_data, uint16_t size);`           |               `void`                |
-|    Receive the remaining data in case of long messages             |          `Luos_ReceiveData(service_t *service, msg_t *msg, void *bin_data);`                 | `data size at the end of reception` |
+
+|                     Description                     |                                    Function                                     |               Return                |
+| :-------------------------------------------------: | :-----------------------------------------------------------------------------: | :---------------------------------: |
+|  Send the remaining data in case of long messages   | `Luos_SendData(service_t *service, msg_t *msg, void *bin_data, uint16_t size);` |               `void`                |
+| Receive the remaining data in case of long messages |       `Luos_ReceiveData(service_t *service, msg_t *msg, void *bin_data);`       | `data size at the end of reception` |
 
 ## Luos pub/sub functions
-|                        Description                                 |                                       Function                                               |               Return                |
-| :--------------------------------------------------------:         | :------------------------------------------------------------------------------------------: | :---------------------------------: |
-|       Subscribe to a new topic for pub/sub messages                |              `Luos_Subscribe(service_t *service, uint16_t topic);`                           |          `error_return_t`           |
-|       Unsubscribe from a topic for pub/sub messages                |             `Luos_Unsubscribe(service_t *service, uint16_t topic);`                          |          `error_return_t`           |
+
+|                  Description                  |                        Function                         |      Return      |
+| :-------------------------------------------: | :-----------------------------------------------------: | :--------------: |
+| Subscribe to a new topic for pub/sub messages |  `Luos_Subscribe(service_t *service, uint16_t topic);`  | `error_return_t` |
+| Unsubscribe from a topic for pub/sub messages | `Luos_Unsubscribe(service_t *service, uint16_t topic);` | `error_return_t` |
 
 ## Luos streaming messaging management functions
-|                        Description                                 |                                       Function                                                             |               Return                |
-| :--------------------------------------------------------:         | :--------------------------------------------------------------------------------------------------------: | :---------------------------------: |
-|          Send data stored in a streaming channel                   |  `Luos_SendStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);`                        |               `void`                |
-| Send a specific quantity of data stored in a streaming channel     |  `Luos_SendStreamingSize(service_t *service, msg_t *msg, streaming_channel_t *stream, uint32_t max_size);` |               `void`                |
-|           Receive data from a streaming channel                    | `Luos_ReceiveStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);`                      |          `error_return_t`           |
+
+|                          Description                           |                                                 Function                                                  |      Return      |
+| :------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------: | :--------------: |
+|            Send data stored in a streaming channel             |            `Luos_SendStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);`             |      `void`      |
+| Send a specific quantity of data stored in a streaming channel | `Luos_SendStreamingSize(service_t *service, msg_t *msg, streaming_channel_t *stream, uint32_t max_size);` |      `void`      |
+|             Receive data from a streaming channel              |           `Luos_ReceiveStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);`           | `error_return_t` |
 
 ## Luos streaming buffer functions
-|                  Description                   |                             Function                             |       Return       |
-| :--------------------------------------------: | :--------------------------------------------------------------: | :----------------: |
-|  Create a streaming rung buffer                | `Streaming_CreateChannel(const void *ring_buffer, uint16_t ring_buffer_size, uint8_t data_size);` | `streaming_channel_t`  |
-|            Reset the streaming buffer          |     `Streaming_ResetChannel(streaming_channel_t *stream);`       | `void` |
-|      Write samples in the buffer               |       `Streaming_PutSample(streaming_channel_t *stream, const void *data, uint16_t size);`       | `uint16_t` |
-|      Get samples from the buffer               |   `Streaming_GetSample(streaming_channel_t *stream, void *data, uint16_t size);`    | `uint16_t` |
-| Get the number of available sample in the buffer |   `Streaming_GetAvailableSampleNB(streaming_channel_t *stream);`    | `uint16_t` |
-| Get the number of available before the buffer end|     `Streaming_GetAvailableSampleNBUntilEndBuffer(streaming_channel_t *stream);`      | `uint16_t` |
-| Indicate to the streaming structure that samples have been added to the buffer (this is mostly used with DMA) | `Streaming_AddAvailableSampleNB(streaming_channel_t *stream, uint16_t size);` | `uint16_t` |
-| Indicate to the streaming structure that samples have been consumed from the buffer (this is mostly used with DMA) | `Streaming_RmvAvailableSampleNB(streaming_channel_t *stream, uint16_t size);` | `uint16_t` |
+
+|                                                    Description                                                     |                                             Function                                              |        Return         |
+| :----------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------: | :-------------------: |
+|                                           Create a streaming rung buffer                                           | `Streaming_CreateChannel(const void *ring_buffer, uint16_t ring_buffer_size, uint8_t data_size);` | `streaming_channel_t` |
+|                                             Reset the streaming buffer                                             |                      `Streaming_ResetChannel(streaming_channel_t *stream);`                       |        `void`         |
+|                                            Write samples in the buffer                                             |       `Streaming_PutSample(streaming_channel_t *stream, const void *data, uint16_t size);`        |      `uint16_t`       |
+|                                            Get samples from the buffer                                             |          `Streaming_GetSample(streaming_channel_t *stream, void *data, uint16_t size);`           |      `uint16_t`       |
+|                                  Get the number of available sample in the buffer                                  |                  `Streaming_GetAvailableSampleNB(streaming_channel_t *stream);`                   |      `uint16_t`       |
+|                                 Get the number of available before the buffer end                                  |           `Streaming_GetAvailableSampleNBUntilEndBuffer(streaming_channel_t *stream);`            |      `uint16_t`       |
+|   Indicate to the streaming structure that samples have been added to the buffer (this is mostly used with DMA)    |           `Streaming_AddAvailableSampleNB(streaming_channel_t *stream, uint16_t size);`           |      `uint16_t`       |
+| Indicate to the streaming structure that samples have been consumed from the buffer (this is mostly used with DMA) |           `Streaming_RmvAvailableSampleNB(streaming_channel_t *stream, uint16_t size);`           |      `uint16_t`       |

--- a/apps/documentation/docs/luos-technology/messages/object-dictionary.mdx
+++ b/apps/documentation/docs/luos-technology/messages/object-dictionary.mdx
@@ -92,7 +92,7 @@ Here are listed the existing types:
 | angular_position |                      deg, revolution, rad                       |
 |  angular_speed   |           deg/s, revolution/s, revolution/min, rad/s            |
 |      force       |                        N, kgf, ozf, lbf                         |
-|      moment      |     N.mm, N.cm, N.m, kgf.mm, kgf.cm, kgf.m, ozf.in, lbf.in      |
+|      torque      |     N.mm, N.cm, N.m, kgf.mm, kgf.cm, kgf.m, ozf.in, lbf.in      |
 |     voltage      |                              mV, V                              |
 |     current      |                              mA, A                              |
 |      power       |                              mW, W                              |

--- a/apps/documentation/docs/luos-technology/node/luos.mdx
+++ b/apps/documentation/docs/luos-technology/node/luos.mdx
@@ -129,7 +129,8 @@ You can use it to set all your custom configurations to fit your design:
 | :----------------------: | :---------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------: |
 |     MAX_NODE_NUMBER      |              20               |                                       Max number of node that could be detected on the architecture.                                        |
 |    MAX_SERVICE_NUMBER    |              20               |                                     Max number of services that could be detected in the architecture.                                      |
-| MAX_LOCAL_SERVICE_NUMBER |               5               |                                                       Number of services in the node.                                                       |
+| MAX_LOCAL_SERVICE_NUMBER |               5               |                                                     Max number of services in the node.                                                     |
+| MAX_AUTO_REFRESH_NUMBER  |   MAX_LOCAL_SERVICE_NUMBER    |                                                   Max number of auto_refresh in the node.                                                   |
 |  MAX_LOCAL_TOPIC_NUMBER  |              20               |                                        Max number of pub/sub topics used by all the local services.                                         |
 | MAX_LOCAL_PROFILE_NUMBER |   MAX_LOCAL_SERVICE_NUMBER    |                                           Max number of profiles used by all the local services.                                            |
 |       LOCAL_PHY_NB       |               1               |                                           Max number of different network interface on the node.                                            |

--- a/apps/documentation/docs/luos-technology/node/luos.mdx
+++ b/apps/documentation/docs/luos-technology/node/luos.mdx
@@ -125,25 +125,22 @@ You can use it to set all your custom configurations to fit your design:
 - for the phys of your node
 - for the Luos engine of your node
 
-|     Parameters           |    Defaults value             |                                                    Description                                                                              |
-| :-----------------------:| :---------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------: |
-|   MAX_NODE_NUMBER        |          20                   |     Max number of node that could be detected on the architecture.                                                                          |
-| MAX_SERVICE_NUMBER       |          20                   |     Max number of services that could be detected in the architecture.                                                                      |
-| MAX_LOCAL_SERVICE_NUMBER |           5                   |                               Number of services in the node.                                                                               |
-| MAX_LOCAL_TOPIC_NUMBER   |          20                   | Max number of pub/sub topics used by all the local services.                                                                                |
-| MAX_LOCAL_PROFILE_NUMBER | MAX_LOCAL_SERVICE_NUMBER      | Max number of profiles used by all the local services.                                                                                      |
-| LOCAL_PHY_NB             | 1                             | Max number of different network interface on the node.                                                                                      |
-|  MSG_BUFFER_SIZE         |      3 \* max_msg_size        |         Size of the Luos message storage. Messages waiting to be treated or re-transmitted are stored in this buffer.                       |
-|     MAX_MSG_NB           | 2 \* MAX_LOCAL_SERVICE_NUMBER |                        The max number of messages that can be referenced by Luos at the same time.                                          |
-|     BOOTLOADER           | undefined                     | By adding this flag you will compile Luos_engine as a bootloader (learn more about it [here](/tutorials/bootloader)).                       |
-| BOOTLOADER_UPDATER       | undefined                     | By adding this flag you will compile Luos_engine as a bootloader updater (learn more about it [here](/tutorials/bootloader)).               |
-| WITH_BOOTLOADER          | undefined                     | By adding this flag you will compile Luos_engine to run on top of a bootloader  (learn more about it [here](/tutorials/bootloader)).        |
-| NO_RTB                   | undefined                     | By adding this flag you will compile Luos_engine without any routing table management. Use it to save RAM if you only have driver services. |
+|        Parameters        |        Defaults value         |                                                                 Description                                                                 |
+| :----------------------: | :---------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------: |
+|     MAX_NODE_NUMBER      |              20               |                                       Max number of node that could be detected on the architecture.                                        |
+|    MAX_SERVICE_NUMBER    |              20               |                                     Max number of services that could be detected in the architecture.                                      |
+| MAX_LOCAL_SERVICE_NUMBER |               5               |                                                       Number of services in the node.                                                       |
+|  MAX_LOCAL_TOPIC_NUMBER  |              20               |                                        Max number of pub/sub topics used by all the local services.                                         |
+| MAX_LOCAL_PROFILE_NUMBER |   MAX_LOCAL_SERVICE_NUMBER    |                                           Max number of profiles used by all the local services.                                            |
+|       LOCAL_PHY_NB       |               1               |                                           Max number of different network interface on the node.                                            |
+|     MSG_BUFFER_SIZE      |       3 \* max_msg_size       |                Size of the Luos message storage. Messages waiting to be treated or re-transmitted are stored in this buffer.                |
+|        MAX_MSG_NB        | 2 \* MAX_LOCAL_SERVICE_NUMBER |                                 The max number of messages that can be referenced by Luos at the same time.                                 |
+|        BOOTLOADER        |           undefined           |            By adding this flag you will compile Luos_engine as a bootloader (learn more about it [here](/tutorials/bootloader)).            |
+|    BOOTLOADER_UPDATER    |           undefined           |        By adding this flag you will compile Luos_engine as a bootloader updater (learn more about it [here](/tutorials/bootloader)).        |
+|     WITH_BOOTLOADER      |           undefined           |     By adding this flag you will compile Luos_engine to run on top of a bootloader (learn more about it [here](/tutorials/bootloader)).     |
+|          NO_RTB          |           undefined           | By adding this flag you will compile Luos_engine without any routing table management. Use it to save RAM if you only have driver services. |
 
-
-
-
-You will find the default configuration for Luos engine in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/engine_config.h" target="_blank" rel="external nofollow">engine\_config.h<IconExternalLink width="10"></IconExternalLink>_</a>.
+You will find the default configuration for Luos engine in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/engine_config.h" target="_blank" rel="external nofollow">engine_config.h<IconExternalLink width="10"></IconExternalLink>\_</a>.
 
 Check the _Luos_hal_config.h_ and your _Network_hal_config.h_ of your MCU family to see parameters that can be changed to fit your design.
 

--- a/apps/documentation/docs/networks/robus/mcu.mdx
+++ b/apps/documentation/docs/networks/robus/mcu.mdx
@@ -12,22 +12,23 @@ import TabItem from '@theme/TabItem';
 Robus allows you to configure some aspects of the protocol to adapt it to your needs. To modify these options, you have to define them in your `product_config.h` file.
 Learn more about `product_config.h` on the [code organization page](../../luos-technology/basics/organization).
 
-|              Function               |                    Description                    |             Comments             |
-| :---------------------------------: | :-----------------------------------------------: | :------------------------------: |
-|          ROBUS_NETWORK_BAUDRATE     |   Define the serial baudrate used by Robus        | By default the baudrate is 1000000 |
-|          NBR_RETRY     |   Define the maximum number of transmission attempt before excluding the node from the network        | By default Robus will perform 10 retry maximum |
-|          NBR_PORT     |   The number of physical port (or PTP) you have on your setup        | By default Robus consider that you have 2 of them |
+|        Function        |                                         Description                                          |                     Comments                      |
+| :--------------------: | :------------------------------------------------------------------------------------------: | :-----------------------------------------------: |
+| ROBUS_NETWORK_BAUDRATE |                           Define the serial baudrate used by Robus                           |        By default the baudrate is 1000000         |
+|       NBR_RETRY        | Define the maximum number of transmission attempt before excluding the node from the network |  By default Robus will perform 10 retry maximum   |
+|        NBR_PORT        |                 The number of physical port (or PTP) you have on your setup                  | By default Robus consider that you have 2 of them |
 
 ## Compatible MCUs
 
 Robus can manage any type of microcontrollers as long as they have a HAL. If your microcontroller is not supported yet, please contact us:
 
 - on <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Discord</a>
-- on <a href="https://github.com/Luos-io/ROBUS_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
+- on <a href="https://github.com/Luos-io/luos_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
 
-Check the list of MCU families Robus cover:<a href="https://github.com/Luos-io/ROBUS_engine/tree/main/network/robus/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
+Check the list of MCU families Robus cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
 
 ## Default Configurations
+
 Robus is made to run on real-time microcontrollers and use the hardware peripherals to complete communication between nodes. In order to configure this low-level part, Robus provide, for many MCU families, a default configuration that can be followed to plug and play the Robus package with the chosen MCU family. The peripheral configuration is described in the _robus_hal_config.h_ files, and can be redefined in the _node_config.h_ file of your project to fit with your design.
 
 <a
@@ -40,10 +41,10 @@ Robus is made to run on real-time microcontrollers and use the hardware peripher
 
 ## Robus's HAL configuration
 
-To tailor the pinout and functionality according to your design requirements, you can either create or utilize the file _node_config.h_ (refer to [Luos examples](https://github.com/Luos-io/ROBUS_engine/tree/main/examples)).
+To tailor the pinout and functionality according to your design requirements, you can either create or utilize the file _node_config.h_ (refer to [Luos examples](https://github.com/Luos-io/luos_engine/tree/main/examples)).
 In the "ROBUS HAL LIBRARY DEFINITION" section of the _node_config.h_ file, you can define pinout, USART settings, timers, and more, building upon the default configuration defined in _robus_hal_config.h_.
 
-:::info 
+:::info
 Each example provided by Luos has a _node_config.h_ file and includes the file _platformio.ini_.
 :::
 
@@ -78,19 +79,19 @@ There are many possible configurations that you can change, not all of them bein
 </TabItem>
 <TabItem value="Communication" label="Communication">
 
-|                 Function                  |             Description              |            Comments             |
-| :---------------------------------------: | :----------------------------------: | :-----------------------------: |
-|           ROBUS_COM_CLOCK_ENABLE           |      Activates clock for serial      |      Depends on serial bus      |
-| ROBUS_COM/ROBUS_COM_IRQ/ROBUS_COM_IRQHANDLER | Chooses serial bus, IRQ and callback | Adapts to the serial bus chosen |
-|           ROBUS_DMA_CLOCK_ENABLE           |       Activates clock for DMA        |      Necessary for for Tx       |
-|             ROBUS_DMA/ROBUS_DMA_CHANNEL/ROBUS_DMA_REQUEST              |           Chooses DMA Channel and peripheral            |          Message Tx on serial port            |
+|                   Function                    |             Description              |            Comments             |
+| :-------------------------------------------: | :----------------------------------: | :-----------------------------: |
+|            ROBUS_COM_CLOCK_ENABLE             |      Activates clock for serial      |      Depends on serial bus      |
+| ROBUS_COM/ROBUS_COM_IRQ/ROBUS_COM_IRQHANDLER  | Chooses serial bus, IRQ and callback | Adapts to the serial bus chosen |
+|            ROBUS_DMA_CLOCK_ENABLE             |       Activates clock for DMA        |      Necessary for for Tx       |
+| ROBUS_DMA/ROBUS_DMA_CHANNEL/ROBUS_DMA_REQUEST |  Chooses DMA Channel and peripheral  |    Message Tx on serial port    |
 
 </TabItem>
 <TabItem value="Timer" label="Timer">
 
-|                    Function                     |           Description           |       Comments        |
-| :---------------------------------------------: | :-----------------------------: | :-------------------: |
-|             ROBUS_TIMER_CLOCK_ENABLE             |   Activates clock for Timeout   | Necessary for Timeout |
+|                      Function                      |           Description           |       Comments        |
+| :------------------------------------------------: | :-----------------------------: | :-------------------: |
+|              ROBUS_TIMER_CLOCK_ENABLE              |   Activates clock for Timeout   | Necessary for Timeout |
 | ROBUS_TIMER/ROBUS_TIMER_IRQ/ROBUS_TIMER_IRQHANDLER | Chooses Timer, IRQ and callback | Necessary for Timeout |
 
 </TabItem>

--- a/apps/documentation/docs/networks/serial/config.mdx
+++ b/apps/documentation/docs/networks/serial/config.mdx
@@ -12,22 +12,22 @@ import TabItem from '@theme/TabItem';
 The Serial network allows you to configure some aspects of the protocol to adapt it to your needs. To modify these options, you have to define them in your `product_config.h` file.
 Learn more about `product_config.h` on the [code organization page](../../luos-technology/basics/organization).
 
-|              Function               |                    Description                    |             Comments             |
-| :---------------------------------: | :-----------------------------------------------: | :------------------------------: |
-|          SERIAL_NETWORK_BAUDRATE    |   Define the serial baudrate used by the Luos Serial protocol        | By default the baudrate is 1000000 |
-|          SERIAL_RX_BUFFER_SIZE      |   The size of the RX buffer        | By default this buffer have 512 bytes. However  this value is very conservative and the serial rarely need more than 10 bytes. |
-
+|        Function         |                         Description                         |                                                           Comments                                                            |
+| :---------------------: | :---------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------: |
+| SERIAL_NETWORK_BAUDRATE | Define the serial baudrate used by the Luos Serial protocol |                                              By default the baudrate is 1000000                                               |
+|  SERIAL_RX_BUFFER_SIZE  |                  The size of the RX buffer                  | By default this buffer have 512 bytes. However this value is very conservative and the serial rarely need more than 10 bytes. |
 
 ## Compatible MCUs
 
 Serial can manage any type of microcontrollers as long as they have a HAL. If your microcontroller is not supported yet, please contact us:
 
 - on <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Discord</a>
-- on <a href="https://github.com/Luos-io/ROBUS_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
+- on <a href="https://github.com/Luos-io/luos_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
 
-Check the list of MCU families Serial cover:<a href="https://github.com/Luos-io/ROBUS_engine/tree/main/network/serial/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
+Check the list of MCU families Serial cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/network/serial_network/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
 
 ## Default Configurations
+
 Serial can run on absolutely any kind of micocontroller or computer. This is the most maintream communication bus. The peripheral configuration is described in the _serial_hal_config.h_ files, and can be redefined in the _node_config.h_ file of your project to fit with your design.
 
 <a
@@ -40,50 +40,50 @@ Serial can run on absolutely any kind of micocontroller or computer. This is the
 
 ## Serial's HAL configuration
 
-To tailor the pinout and functionality according to your design requirements, you can either create or utilize the file _node_config.h_ (refer to [Luos examples](https://github.com/Luos-io/ROBUS_engine/tree/main/examples)).
+To tailor the pinout and functionality according to your design requirements, you can either create or utilize the file _node_config.h_ (refer to [Luos examples](https://github.com/Luos-io/luos_engine/tree/main/examples)).
 In the "SERIAL HAL LIBRARY DEFINITION" section of the _node_config.h_ file of compatible examples, you can define pinout, USART settings, and optionally DMA, building upon the default configuration defined in _serial_hal_config.h_.
 
-:::info 
+:::info
 Each example provided by Luos has a _node_config.h_ file and includes the file _platformio.ini_.
 :::
 
 <Tabs>
     <TabItem value="Pinout" label="Pinout">
 
-|              Function               |                    Description                             |             Comments             |
-| :---------------------------------: | :--------------------------------------------------------: | :------------------------------: |
-| SERIAL_TX_CLK/SERIAL_RX_CLK         |             Activates clock for GPIO                       |         Depends on port          |
-|        SERIAL_TX_PIN/SERIAL_RX_PIN  |          Chooses pinout for Rx/Tx comms                    | Adapts to the chosen serial bus  |
-|        SERIAL_TX_PORT/SERIAL_RX_PORT|          Chooses Rx/Tx pin ports                           |     Depends on selected pins     |
-|         SERIAL_TX_AF/SERIAL_RX_AF   | Chooses pins atlternate functions to activate Rx/Tx comms  | Necessary to enable the serial on these pins |
+|           Function            |                        Description                        |                   Comments                   |
+| :---------------------------: | :-------------------------------------------------------: | :------------------------------------------: |
+|  SERIAL_TX_CLK/SERIAL_RX_CLK  |                 Activates clock for GPIO                  |               Depends on port                |
+|  SERIAL_TX_PIN/SERIAL_RX_PIN  |              Chooses pinout for Rx/Tx comms               |       Adapts to the chosen serial bus        |
+| SERIAL_TX_PORT/SERIAL_RX_PORT |                  Chooses Rx/Tx pin ports                  |           Depends on selected pins           |
+|   SERIAL_TX_AF/SERIAL_RX_AF   | Chooses pins atlternate functions to activate Rx/Tx comms | Necessary to enable the serial on these pins |
 
 </TabItem>
 <TabItem value="Communication" label="Communication">
 
-|                 Function                  |             Description              |            Comments             |
-| :---------------------------------------: | :----------------------------------: | :-----------------------------: |
-|           SERIAL_COM_CLOCK_ENABLE           |      Activates clock for serial      |      Depends on serial bus      |
+|                    Function                     |             Description              |            Comments             |
+| :---------------------------------------------: | :----------------------------------: | :-----------------------------: |
+|             SERIAL_COM_CLOCK_ENABLE             |      Activates clock for serial      |      Depends on serial bus      |
 | SERIAL_COM/SERIAL_COM_IRQ/SERIAL_COM_IRQHANDLER | Chooses serial bus, IRQ and callback | Adapts to the serial bus chosen |
 
 </TabItem>
 <TabItem value="RX DMA" label="RX DMA(optional)">
 
-|                    Function                     |           Description           |       Comments        |
-| :---------------------------------------------: | :-----------------------------: | :-------------------: |
-|             SERIAL_RX_DMA_CLOCK_ENABLE             |   Activates clock for DMA   | Necessary for DMA |
-| SERIAL_RX_DMA/SERIAL_RX_DMA_CHANNEL/SERIAL_RX_DMA_REQUEST | Chooses The DMA and the link with Serial | Necessary for DMA |
-| SERIAL_RX_DMA_TC/SERIAL_RX_DMA_CLEAR_TC | Indicate the transfert complete interface | Necessary for transfert complete event |
+|                         Function                          |                Description                |                Comments                |
+| :-------------------------------------------------------: | :---------------------------------------: | :------------------------------------: |
+|                SERIAL_RX_DMA_CLOCK_ENABLE                 |          Activates clock for DMA          |           Necessary for DMA            |
+| SERIAL_RX_DMA/SERIAL_RX_DMA_CHANNEL/SERIAL_RX_DMA_REQUEST | Chooses The DMA and the link with Serial  |           Necessary for DMA            |
+|          SERIAL_RX_DMA_TC/SERIAL_RX_DMA_CLEAR_TC          | Indicate the transfert complete interface | Necessary for transfert complete event |
 
 </TabItem>
 
 <TabItem value="TX DMA" label="TX DMA(optional)">
 
-|                    Function                     |           Description           |       Comments        |
-| :---------------------------------------------: | :-----------------------------: | :-------------------: |
-|             SERIAL_TX_DMA_CLOCK_ENABLE             |   Activates clock for DMA   | Necessary for DMA |
-| SERIAL_TX_DMA/SERIAL_TX_DMA_CHANNEL/SERIAL_TX_DMA_REQUEST | Chooses The DMA and the link with Serial | Necessary for DMA |
-| SERIAL_TX_DMA_TC/SERIAL_TX_DMA_CLEAR_TC | Indicate the transfert complete interface | Necessary for transfert complete event |
-| SERIAL_TX_DMA_IRQ/SERIAL_TX_DMA_IRQHANDLER | Manage the IRQ callback | Necessary for transfert complete event |
+|                         Function                          |                Description                |                Comments                |
+| :-------------------------------------------------------: | :---------------------------------------: | :------------------------------------: |
+|                SERIAL_TX_DMA_CLOCK_ENABLE                 |          Activates clock for DMA          |           Necessary for DMA            |
+| SERIAL_TX_DMA/SERIAL_TX_DMA_CHANNEL/SERIAL_TX_DMA_REQUEST | Chooses The DMA and the link with Serial  |           Necessary for DMA            |
+|          SERIAL_TX_DMA_TC/SERIAL_TX_DMA_CLEAR_TC          | Indicate the transfert complete interface | Necessary for transfert complete event |
+|        SERIAL_TX_DMA_IRQ/SERIAL_TX_DMA_IRQHANDLER         |          Manage the IRQ callback          | Necessary for transfert complete event |
 
 </TabItem>
 

--- a/apps/documentation/docs/networks/websocket/config.mdx
+++ b/apps/documentation/docs/networks/websocket/config.mdx
@@ -1,0 +1,57 @@
+---
+custom_edit_url: null
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Websocket configuration
+
+## Protocol configuration
+
+The websocket network allows you to configure some aspects of the protocol to adapt it to your needs. To modify these options, you have to define them in your `product_config.h` file.
+Learn more about `product_config.h` on the [code organization page](../../luos-technology/basics/organization).
+
+|        Function        |              Description              |                    Comments                     |
+| :--------------------: | :-----------------------------------: | :---------------------------------------------: |
+| WS_NETWORK_BROKER_ADDR | Use it to define your broker address. | By default the address is "ws://127.0.0.1:8000" |
+
+## Compatible MCUs
+
+Webcocket can manage board with wifi or ethernet connectivity. For now only Arduino and Native configurations are ready. If your microcontroller is not supported yet, please contact us:
+
+- on <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Discord</a>
+- on <a href="https://github.com/Luos-io/luos_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
+
+Check the list of MCU families Websocket cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/network/ws_network/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
+
+## Default Configurations
+
+The WebSocket network is very usefull if you need to interact with some applications running on the web or web based. This network need to connect to a running broker application.
+
+:::info
+To run a broker, please use pyluos and run the `pyluos-ws-broker` command.
+:::
+
+The peripheral configuration is described in the _ws_hal_config.h_ files, and can be redefined in the _node_config.h_ file of your project to fit with your design.
+
+<a
+  href="../../luos-technology/basics/organization"
+  className="pagination-nav__link"
+  style={{ display: 'inline-block' }}
+>
+  Learn more about project organization
+</a>
+
+## WebSocket's HAL configuration
+
+When you use the websocket network in an embedded system, the network code will also have to manage the wifi connectivity. You will have to define the SSID and password of your wifi network in the _node_config.h_ file of your project.
+
+:::info
+Each example provided by Luos has a _node_config.h_ file and includes the file _platformio.ini_.
+:::
+
+|  Function   |    Description    |
+| :---------: | :---------------: |
+| SECRET_SSID |   The wifi SSID   |
+| SECRET_PASS | The wifi password |

--- a/apps/documentation/docs/networks/websocket/minimum-requirements.mdx
+++ b/apps/documentation/docs/networks/websocket/minimum-requirements.mdx
@@ -1,0 +1,15 @@
+---
+custom_edit_url: null
+---
+
+# Minimum requirements
+
+|  Hardware  |         Specification         |
+| :--------: | :---------------------------: |
+|   Flash    |             1.7KB             |
+|    RAM     |              37B              |
+| Ressources | Wifi or ethernet connectivity |
+
+## Websocket network performances
+
+WebSocket is a good solution to interact with a web application or a web based application. It is not a good solution to interact with a real time application. Don't expect to have a good reactivity with this network.

--- a/apps/documentation/docs/networks/websocket/websocket.mdx
+++ b/apps/documentation/docs/networks/websocket/websocket.mdx
@@ -1,0 +1,35 @@
+---
+hide_title: true
+hide_table_of_contents: true
+custom_edit_url: null
+title: 'WebSocket network'
+---
+
+import IconExternalLink from '@theme/Icon/ExternalLink';
+import Image from '@site/src/components/Image';
+
+# Network capabilities
+
+|              Feature               |                                                  Status                                                   |
+| :--------------------------------: | :-------------------------------------------------------------------------------------------------------: |
+|             Multipoint             |                                         ✅ (thanks to the broker)                                         |
+| Deterministc topological detection |                                                    ❌                                                     |
+|      Messages acknoledgement       |                              ❌ (already managed by the WebSocket protocol)                               |
+|        Messages timestamps         |                                                    ❌                                                     |
+|              Protocol              |                                                 WebSocket                                                 |
+|                Bus                 |                                                   TCPIP                                                   |
+|      Overhead on top of Luos       |                                                   a lot                                                   |
+|  Package performances indications  | Do nont use WebSocket for high density messaging or time constrained applications. (1.7K FLASH, 0.7K RAM) |
+
+# WebSocket
+
+The Websocket network is the default network used to communicate over a TCP/IP network. You cna use it to run application on both side, computer and embedded system.
+Keep in mind that this network is not deterministic and is not made to run real time application. This is a good solution to interact with a web application or a web based application.
+Your board will need to be connected to a wifi or ethernet network to be able to communicate with other nodes.
+You will have to take care of your network port configuration to be able to communicate with your board.
+
+This network need to connect to a running broker application. The ws Address you will have to configure in your product_config.h file will be the address of the broker.
+
+:::info
+To run a broker, please use pyluos and run the `pyluos-ws-broker` command.
+:::

--- a/apps/documentation/docs/tools/api-json.mdx
+++ b/apps/documentation/docs/tools/api-json.mdx
@@ -207,6 +207,7 @@ Here is the list of all values that services can use:
 |   target_rot_speed    |                                                   Actuator's target rotation speed                                                   |
 | target_trans_position |                                   Actuator's target linear position (can be a number or an array)                                    |
 |  target_trans_speed   |                                                    Actuator's target linear speed                                                    |
+|     target_torque     |                                                       Actuator's target torque                                                       |
 |         time          |                                                              Time value                                                              |
 |       compliant       |                                                     Actuator's compliance status                                                     |
 |          pid          |                                        Set of PID values (proportional, integral, derivative)                                        |
@@ -230,7 +231,7 @@ Here is the list of all values that services can use:
 |          lux          |                                                     Lux (light intensity) value                                                      |
 |      temperature      |                                                          Temperature value                                                           |
 |         force         |                                                             Force value                                                              |
-|        moment         |                                                             Torque value                                                             |
+|        torque         |                                                             Torque value                                                             |
 |         power         |                                                             Power value                                                              |
 |     linear_accel      |                                                      Linear acceleration value                                                       |
 |    gravity_vector     |                                                         Gravity vector value                                                         |

--- a/apps/documentation/docs/tools/gate.mdx
+++ b/apps/documentation/docs/tools/gate.mdx
@@ -94,8 +94,6 @@ You could need to change it if you have apps on your Luos embedded system.
 
 If you have an app service on your device managing detections you should define **NODETECTION** avoiding useless detection from the gate at boot.
 
-If you have an app service on your device using auto-update you should define **GATE_POLLING** avoiding the gate to take the lead on the services your App is using.
-
 ## Gate custom conversion
 
 The Gate is allowing you to create you own custom conversion.

--- a/apps/documentation/docs/tools/gate.mdx
+++ b/apps/documentation/docs/tools/gate.mdx
@@ -96,8 +96,18 @@ If you have an app service on your device managing detections you should define 
 
 ## Gate custom conversion
 
-The Gate is allowing you to create you own custom conversion.
-If you are using Platformio, this specific configuration have to be managed on the `build_flags`. more information on the [Platformio page](platformio)
+The Gate is allowing you to create you own custom conversion (other than the default Json) or custom command management.
+
+### Adding custom commands
+
+In your projects, you will probably have to create custom commands and manage them on your gate. To do so, you can add your custom command conversions from the default `TinyJSON` conversion using the specifically exposed function.
+This specific conversion code can be added to specific functions that need to be compiled with your node containing your gate service.
+You can find an example of this specific conversion and an explanation of those functions on the [custom Gate example](https://github.com/Luos-io/luos_engine/blob/main/examples/projects/product/custom_gate/src/custom_json_conversion.c).
+
+### Adding custom conversion
+
+Alternatively, you may need to create your own conversion format to use something other than JSON. To do this, you will have to replace the default `TinyJSON` conversion folder with your own during compilation.
+If you are using Platformio, this specific configuration have to be managed on the `build_flags` (more information on the [Platformio page](platformio)).
 
 To do so you have to :
 

--- a/apps/documentation/docs/tools/gate.mdx
+++ b/apps/documentation/docs/tools/gate.mdx
@@ -85,24 +85,25 @@ The default process described above can be changed using different configuration
 
 You could need to change it if you have apps on your Luos embedded system.
 
-|   Parameters   | Defaults value |                               Description                                |
-| :------------: | :------------: | :----------------------------------------------------------------------: |
-| GATE_BUFF_SIZE |      1024      |                    Maximum size of 1 formatted Data.                     |
-|  GATE_POLLING  |  NOT DEFINED   | No auto-refresh, always ask for data (more intensive to Luos bandwidth). |
-|  NODETECTION   |  NOT DEFINED   | Gate does not make detection at power up. Use it only if you have another app performing the detection  |
-|  INIT_TIME     |  150           | Number of millisecond allowing all node to properly start before launching a detection. |
+|   Parameters   | Defaults value |                                              Description                                               |
+| :------------: | :------------: | :----------------------------------------------------------------------------------------------------: |
+| GATE_BUFF_SIZE |      1024      |                                   Maximum size of 1 formatted Data.                                    |
+|  GATE_POLLING  |  NOT DEFINED   |                No auto-refresh, always ask for data (more intensive to Luos bandwidth).                |
+|  NODETECTION   |  NOT DEFINED   | Gate does not make detection at power up. Use it only if you have another app performing the detection |
+|   INIT_TIME    |      150       |        Number of millisecond allowing all node to properly start before launching a detection.         |
 
 If you have an app service on your device managing detections you should define **NODETECTION** avoiding useless detection from the gate at boot.
 
 If you have an app service on your device using auto-update you should define **GATE_POLLING** avoiding the gate to take the lead on the services your App is using.
 
 ## Gate custom conversion
+
 The Gate is allowing you to create you own custom conversion.
 If you are using Platformio, this specific configuration have to be managed on the `build_flags`. more information on the [Platformio page](platformio)
 
 To do so you have to :
- - use [the `TinyJSON` default conversion](https://github.com/Luos-io/luos_engine/tree/main/tool_services/gate/TinyJSON) code as reference. Copy paste it on your `lib` folder
- - Rename this folder as you want
- - On your `platformio.ini` modify the Gate conversion format to use your custom one : `-D GATEFORMAT=custom_folder_name`
- - Now you can add and improve the conversion code as you want in your project.
 
+- use [the `TinyJSON` default conversion](https://github.com/Luos-io/luos_engine/tree/main/tool_services/gate/TinyJSON) code as reference. Copy paste it on your `lib` folder
+- Rename this folder as you want
+- On your `platformio.ini` modify the Gate conversion format to use your custom one : `-D GATEFORMAT=custom_folder_name`
+- Now you can add and improve the conversion code as you want in your project.

--- a/apps/documentation/sidebarsDocs.js
+++ b/apps/documentation/sidebarsDocs.js
@@ -274,6 +274,26 @@ module.exports = {
                         },
                     ],
                 },
+                {
+                    type: 'category',
+                    label: 'WebSocket',
+                    link: {
+                        type: 'doc',
+                        id: 'networks/websocket/websocket',
+                    },
+                    items: [
+                        {
+                            type: 'doc',
+                            label: 'Minimum requirements',
+                            id: 'networks/websocket/minimum-requirements',
+                        },
+                        {
+                            type: 'doc',
+                            label: 'WebSocket configuration',
+                            id: 'networks/websocket/config',
+                        },
+                    ],
+                },
             ],
         },
         {

--- a/apps/documentation/src/components/tools/data/Networks/dataNetworks.json
+++ b/apps/documentation/src/components/tools/data/Networks/dataNetworks.json
@@ -10,5 +10,11 @@
         "desc": "This network aim to be as simple and flexible as possible. Use it to extend your boards network to a computer.",
         "link": "/docs/next/networks/serial",
         "img": "/assets/images/advanced-doc/robus/card/LUOS-ROBUS.svg"
+    },
+    {
+        "title": "Websocket",
+        "desc": "This network is usefull when you need to interact with web based applications or services.",
+        "link": "/docs/next/networks/websocket",
+        "img": "/assets/images/advanced-doc/robus/card/LUOS-ROBUS.svg"
     }
 ]

--- a/apps/documentation/tutorials/get-started/get-started3.mdx
+++ b/apps/documentation/tutorials/get-started/get-started3.mdx
@@ -169,17 +169,19 @@ Connect the USB cable of _board 1_ and leave the USB cable of _board 2_ disconne
 
    ```c
    ...
-       Luos_Init();
-       Led_Init();
-       Pipe_Init();
-       Gate_Init();
-       //Blinker_Init(); <== comment this line
+        Luos_Init();
+        Robus_Init();
+        Led_Init();
+        Pipe_Init();
+        Gate_Init();
+        //Blinker_Init(); <== comment this line
    ...
-       Luos_Loop();
-       Led_Loop();
-       Pipe_Loop();
-       Gate_Loop();
-       //Blinker_Loop(); <== comment this line
+        Luos_Loop();
+        Robus_Loop();
+        Led_Loop();
+        Pipe_Loop();
+        Gate_Loop();
+        //Blinker_Loop(); <== comment this line
    ```
 
 :::info
@@ -213,17 +215,19 @@ You should now unplug the USB cable of _board 1_ and connect the USB cable of _b
 
    ```c
    ...
-       Luos_Init();
-       //Led_Init(); <== comment this line
-       //Pipe_Init(); <== comment this line
-       //Gate_Init(); <== comment this line
-       Blinker_Init();
+        Luos_Init();
+        Robus_Init();
+        //Led_Init(); <== comment this line
+        //Pipe_Init(); <== comment this line
+        //Gate_Init(); <== comment this line
+        Blinker_Init();
    ...
-       Luos_Loop();
-       //Led_Loop(); <== comment this line
-       //Pipe_Loop(); <== comment this line
-       //Gate_Loop(); <== comment this line
-       Blinker_Loop();
+        Luos_Loop();
+        Robus_Loop();‡
+        //Led_Loop(); <== comment this line
+        //Pipe_Loop(); <== comment this line
+        //Gate_Loop(); <== comment this line
+        Blinker_Loop();
    ```
 
 :::tip
@@ -293,16 +297,10 @@ To create a link between multiple programs on your computer, Luos will use WebSo
 
 To be able to do that, you need to run a broker that will share any transmitted message with all other programs.
 
-This broker is a simple Python script. To make it run, you need to install _simple_websocket_server_:
-
-```
-pip install simple_websocket_server==0.4.2
-```
-
-Then you can run the broker script on `Get_started/No-Board/`:
+This broker is a simple Python script. To make it run, open a terminal and execute the following command:
 
 ```bash
-python broker.py
+pyluos-ws-broker
 ```
 
 :::info
@@ -310,7 +308,7 @@ By default the broker will use localhost IP address.
 If you want to experiment it using multiple computers, you can configure your IP and port:
 
 ```bash
-python broker.py --ip 'YOUR_LOCAL_IP' -p 8000
+pyluos-ws-broker --ip 'YOUR_LOCAL_IP' -p 8000
 ```
 
 :::
@@ -327,25 +325,23 @@ We will begin by moving the blinker app service from _board 1_ to _board 2_ and 
 
    ```c
    ...
-       Luos_Init();
-       Led_Init();
-       Pipe_Init();
-       Gate_Init();
-       //Blinker_Init(); <== comment this line
+        Luos_Init();
+        Ws_Init();
+        Led_Init();
+        Pipe_Init();
+        Gate_Init();
+        //Blinker_Init(); <== comment this line
    ...
-       Luos_Loop();
-       Led_Loop();
-       Pipe_Loop();
-       Gate_Loop();
-       //Blinker_Loop(); <== comment this line
+        Luos_Loop();
+        Ws_Loop();
+        Led_Loop();
+        Pipe_Loop();
+        Gate_Loop();
+        //Blinker_Loop(); <== comment this line
    ```
 
 :::info
 These lines trigger the initialization and looping execution of all the packages in your project.
-:::
-:::info
-By default the program will use a localhost IP address.
-If you want to experiment it using multiple computers, you can set the broker IP and port in the _node_config.h_ file by replacing `#define WS_BROKER_ADDR "ws://YOUR_LOCAL_IP:8000"` with the correct IP and port.
 :::
 
 4. Build the project.
@@ -370,17 +366,19 @@ For example, the current version has been tested with MinGW-w64 (MSVCRT runtime)
 
    ```c
    ...
-       Luos_Init();
-       //Led_Init(); <== comment this line
-       //Pipe_Init(); <== comment this line
-       //Gate_Init(); <== comment this line
-       Blinker_Init();
+        Luos_Init();
+        Ws_Init();
+        //Led_Init(); <== comment this line
+        //Pipe_Init(); <== comment this line
+        //Gate_Init(); <== comment this line
+        Blinker_Init();
    ...
-       Luos_Loop();
-       //Led_Loop(); <== comment this line
-       //Pipe_Loop(); <== comment this line
-       //Gate_Loop(); <== comment this line
-       Blinker_Loop();
+        Luos_Loop();
+        Ws_Loop();
+        //Led_Loop(); <== comment this line
+        //Pipe_Loop(); <== comment this line
+        //Gate_Loop(); <== comment this line
+        Blinker_Loop();
    ```
 
 :::tip
@@ -463,7 +461,6 @@ device.led.state=False
 ```
 device.blinker.play()
 ```
-
 
 ## 5. Test your skills
 

--- a/apps/documentation/tutorials/your-first-detection/embedded-app.mdx
+++ b/apps/documentation/tutorials/your-first-detection/embedded-app.mdx
@@ -9,7 +9,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Form from '/src/components/typeform/index.js';
 
-
 # Part 3: Full embedded application
 
 ## 1. Introduction
@@ -18,17 +17,18 @@ The purpose of this training is to create a full embedded application that detec
 
 Let's code that and see how cool it is to do it with Luos engine!
 
-## 2. Add the package button
-
-For now, there are tow packages in the project. In the next step, we will add the button package into _main.c_ or _Arduino.ino_.
-
 <Tabs>
 <TabItem value="Arduino" label="Arduino">
 
+## 2. Add the package button
+
+For now, there are tow packages in the project. In the next step, we will add the button package into _Arduino.ino_.
+
 ```c
-#include <luos_engine.h>
+#include "luos_engine.h"
+#include "robus_network.h"
 #include "led.h"
-// the new line to copy and paste
+// The new line to copy and paste:
 #include "button.h"
 #include "switcher.h"
 
@@ -44,8 +44,10 @@ For now, there are tow packages in the project. In the next step, we will add th
 void setup()
 {
     Luos_Init();
+    Robus_Init();
     Led_Init();
-	// the new line to copy and paste
+
+    // The new line to copy and paste:
     Button_Init();
     Switcher_Init();
 }
@@ -57,8 +59,10 @@ void setup()
 void loop()
 {
     Luos_Loop();
+    Robus_Loop();
     Led_Loop();
-	// the new line to copy and paste
+
+    // The new line to copy and paste:
     Button_Loop();
     Switcher_Loop();
 }
@@ -67,11 +71,17 @@ void loop()
 </TabItem>
 <TabItem value="Nucleo" label="Nucleo">
 
+## 2. Add the package button
+
+For now, there are tow packages in the project. In the next step, we will add the button package into _main.c_.
+
 ```c
-#include <luos_engine.h>
+#include "luos_engine.h"
+#include "robus_network.h"
 #include "switcher.h"
 #include "led.h"
-// the new line to copy and paste
+
+// The new line to copy and paste:
 #include "button.h"
 
 void SystemClock_Config(void);
@@ -83,17 +93,21 @@ int main(void)
     MX_GPIO_Init();
 
     Luos_Init();
+    Robus_Init();
     SwitcherInit();
     Led_Init();
-	// the new line to copy and paste
+
+    // The new line to copy and paste:
     Button_Init();
 
     while (1)
     {
         Luos_Loop();
+        Robus_Loop();
         Switcher_Loop();
         Led_Loop();
-		// the new line to copy and paste
+
+        // The new line to copy and paste:
         Button_Loop();
     }
 }
@@ -122,7 +136,7 @@ The button package is now added to your project. we must find its ID to send a m
  ******************************************************************************/
 service_t *switcher_app; // This will be our switcher service
 uint16_t ID_Led;
-// the new line to copy and paste
+// The new line to copy and paste:
 uint16_t ID_Button;
 ```
 
@@ -133,27 +147,27 @@ void Switcher_MsgHandler(service_t *service, const msg_t *msg)
 {
     if (msg->header.cmd == END_DETECTION)
     {
-		search_result_t filter_result;
+        search_result_t filter_result;
         RTFilter_Reset(&filter_result); // Init your filter.
-		// Now your filter_result have the entire routing table. #nofilter ;)
+        // Now your filter_result have the entire routing table. #nofilter ;)
         RTFilter_Alias(&filter_result, "led"); // Filter your filter_result only keep the services with the alias "led"
-		ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
+        ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
 
-		// the three new lines to copy and paste
-		RTFilter_Reset(&filter_result); // Reset your filter.
-		RTFilter_Alias(&filter_result, "button");
-		ID_Button = filter_result.result_table[0]->id;
+        // The three new lines to copy and paste:
+        RTFilter_Reset(&filter_result); // Reset your filter.
+        RTFilter_Alias(&filter_result, "button");
+        ID_Button = filter_result.result_table[0]->id;
 
         if (ID_Led > 0)
         {
-	        msg_t pub_msg;
-	        pub_msg.header.cmd = IO_STATE;
-	        pub_msg.header.target_mode = ID;
-	        pub_msg.header.target =  ID_Led; // configure the target to be our led service ID
-	        pub_msg.header.size = 1;
-	        pub_msg.data[0] = 1;
-	        Luos_SendMsg(switcher_app, &pub_msg);
-		}
+            msg_t pub_msg;
+            pub_msg.header.cmd = IO_STATE;
+            pub_msg.header.target_mode = ID;
+            pub_msg.header.target =  ID_Led; // configure the target to be our led service ID
+            pub_msg.header.size = 1;
+            pub_msg.data[0] = 1;
+            Luos_SendMsg(switcher_app, &pub_msg);
+        }
     }
 }
 ```
@@ -181,7 +195,8 @@ Let's create a variable to track the **LastAsk**:
 service_t *switcher_app; // This will be our switcher service
 uint16_t ID_Led;
 uint16_t ID_Button;
-// the new line to copy and paste
+
+// The new line to copy and paste:
 uint32_t LastAsk;
 
 ```
@@ -194,7 +209,8 @@ void Switcher_Init(void)
     revision_t revision = {1, 0, 0};
     switcher_app = Luos_CreateService(Switcher_MsgHandler, SWITCHER_APP, "Switcher", revision);
     Luos_Detect(switcher_app);
-	// the new line to copy and paste
+
+    // The new line to copy and paste:
     LastAsk = Luos_GetSystick();
 }
 ```
@@ -204,7 +220,7 @@ Check if 10ms have passed:
 ```c
 void Switcher_Loop(void)
 {
-	// the new block to copy and paste
+    // The new block to copy and paste:
     // ask button value every 10ms
     if ((Luos_GetSystick() - LastAsk) > 10)
     {
@@ -223,15 +239,15 @@ This function returns **TRUE** when your system has been entirely detected:
 ```c
 void Switcher_Loop(void)
 {
-	// the new block to copy and paste
+    // The new block to copy and paste:
     if (Luos_IsNodeDetected() == true) // Topology detection completed
     {
-		// ask button value every 10ms
-		if ((Luos_GetSystick() - LastAsk) > 10)
-		{
-			LastAsk = Luos_GetSystick();
-		}
-	}
+        // ask button value every 10ms
+        if ((Luos_GetSystick() - LastAsk) > 10)
+        {
+            LastAsk = Luos_GetSystick();
+        }
+    }
 }
 ```
 
@@ -244,23 +260,23 @@ void Switcher_Loop(void)
 {
     if (Luos_IsNodeDetected() == true) // Topology detection completed
     {
-		    // ask button value every 10ms
-		    if ((Luos_GetSystick() - LastAsk) > 10)
-		    {
-				// the new block to copy and paste
-				if (ID_Button > 0)
-		        {
-					// Ask the button
-				    msg_t pub_msg;
-		            pub_msg.header.cmd = IO_STATE;
-		            pub_msg.header.target_mode = ID;
-		            pub_msg.header.target = ID_Button;
-		            pub_msg.header.size = 0;
-		            Luos_SendMsg(switcher_app, &pub_msg);
-				}
-		        LastAsk = Luos_GetSystick();
-		    }
-		}
+            // ask button value every 10ms
+            if ((Luos_GetSystick() - LastAsk) > 10)
+            {
+                // The new block to copy and paste:
+                if (ID_Button > 0)
+                {
+                    // Ask the button
+                    msg_t pub_msg;
+                    pub_msg.header.cmd = IO_STATE;
+                    pub_msg.header.target_mode = ID;
+                    pub_msg.header.target = ID_Button;
+                    pub_msg.header.size = 0;
+                    Luos_SendMsg(switcher_app, &pub_msg);
+                }
+                LastAsk = Luos_GetSystick();
+            }
+        }
 }
 ```
 
@@ -277,32 +293,32 @@ void Switcher_MsgHandler(service_t *service, const msg_t *msg)
 {
     if (msg->header.cmd == END_DETECTION)
     {
-		search_result_t filter_result;
+        search_result_t filter_result;
         RTFilter_Reset(&filter_result); // Init your filter.
-		// Now your filter_result have the entire routing table. #nofilter ;)
+        // Now your filter_result have the entire routing table. #nofilter ;)
         RTFilter_Alias(&filter_result, "led"); // Filter your filter_result only keep the services with the alias "led"
-		ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
+        ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
 
-		RTFilter_Reset(&filter_result); // Reset your filter.
-		RTFilter_Alias(&filter_result, "button");
-		ID_Button = filter_result.result_table[0]->id;
+        RTFilter_Reset(&filter_result); // Reset your filter.
+        RTFilter_Alias(&filter_result, "button");
+        ID_Button = filter_result.result_table[0]->id;
 
-		if (ID_Led > 0)
+        if (ID_Led > 0)
         {
-	        msg_t pub_msg;
-	        pub_msg.header.cmd = IO_STATE;
-	        pub_msg.header.target_mode = ID;
-	        pub_msg.header.target =  ID_Led // configure the target to be our led service ID
-	        pub_msg.header.size = 1;
-	        pub_msg.data[0] = 1;
-	        Luos_SendMsg(switcher_app, &pub_msg);
-		}
+            msg_t pub_msg;
+            pub_msg.header.cmd = IO_STATE;
+            pub_msg.header.target_mode = ID;
+            pub_msg.header.target =  ID_Led // configure the target to be our led service ID
+            pub_msg.header.size = 1;
+            pub_msg.data[0] = 1;
+            Luos_SendMsg(switcher_app, &pub_msg);
+        }
     }
-	// the new block to copy and paste
-	else if ((msg->header.cmd == IO_STATE) && (msg->header.source == ID_Button))
-	{
-		// Command the led accordingly to the button message
-	}
+    // The new block to copy and paste:
+    else if ((msg->header.cmd == IO_STATE) && (msg->header.source == ID_Button))
+    {
+        // Command the led accordingly to the button message
+    }
 }
 ```
 
@@ -315,31 +331,31 @@ void Switcher_MsgHandler(service_t *service, const msg_t *msg)
 {
     if (msg->header.cmd == END_DETECTION)
     {
-		search_result_t filter_result;
+        search_result_t filter_result;
         RTFilter_Reset(&filter_result); // Init your filter.
-		// Now your filter_result have the entire routing table. #nofilter ;)
+        // Now your filter_result have the entire routing table. #nofilter ;)
         RTFilter_Alias(&filter_result, "led"); // Filter your filter_result only keep the services with the alias "led"
-		ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
+        ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
 
-		RTFilter_Reset(&filter_result); // Reset your filter.
-		RTFilter_Alias(&filter_result, "button");
-		ID_Button = filter_result.result_table[0]->id;
+        RTFilter_Reset(&filter_result); // Reset your filter.
+        RTFilter_Alias(&filter_result, "button");
+        ID_Button = filter_result.result_table[0]->id;
     }
-	else if ((msg->header.cmd == IO_STATE) && (msg->header.source == ID_Button))
-	{
-		// the new block to copy and paste
-		// Command the led accordingly to the button message
-		if (ID_Led > 0)
+    else if ((msg->header.cmd == IO_STATE) && (msg->header.source == ID_Button))
+    {
+        // The new block to copy and paste:
+        // Command the led accordingly to the button message
+        if (ID_Led > 0)
         {
-	        msg_t pub_msg;
-	        pub_msg.header.cmd = IO_STATE;
-	        pub_msg.header.target_mode = ID;
-	        pub_msg.header.target =  ID_Led // configure the target to be our led service ID
-	        pub_msg.header.size = 1;
-	        pub_msg.data[0] = 1;
-	        Luos_SendMsg(switcher_app, &pub_msg);
-		}
-	}
+            msg_t pub_msg;
+            pub_msg.header.cmd = IO_STATE;
+            pub_msg.header.target_mode = ID;
+            pub_msg.header.target =  ID_Led // configure the target to be our led service ID
+            pub_msg.header.size = 1;
+            pub_msg.data[0] = 1;
+            Luos_SendMsg(switcher_app, &pub_msg);
+        }
+    }
 }
 ```
 
@@ -351,21 +367,21 @@ This button's value is recovered in the first case of the tab data of the button
 
 ```c
 ...
-	else if ((msg->header.cmd == IO_STATE) && (msg->header.source == ID_Button))
-	{
-		// Command the led accordingly to the button message
-		if (ID_Led > 0)
+    else if ((msg->header.cmd == IO_STATE) && (msg->header.source == ID_Button))
+    {
+        // Command the led accordingly to the button message
+        if (ID_Led > 0)
         {
-	        msg_t pub_msg;
-	        pub_msg.header.cmd = IO_STATE;
-	        pub_msg.header.target_mode = ID;
-	        pub_msg.header.target =  ID_Led // configure the target to be our led service ID
-	        pub_msg.header.size = 1;
-			// the new line to copy and paste
-	        pub_msg.data[0] = msg->data[0];
-	        Luos_SendMsg(switcher_app, &pub_msg);
-		}
-	}
+            msg_t pub_msg;
+            pub_msg.header.cmd = IO_STATE;
+            pub_msg.header.target_mode = ID;
+            pub_msg.header.target =  ID_Led // configure the target to be our led service ID
+            pub_msg.header.size = 1;
+            // The new line to copy and paste:
+            pub_msg.data[0] = msg->data[0];
+            Luos_SendMsg(switcher_app, &pub_msg);
+        }
+    }
 ...
 ```
 

--- a/apps/documentation/tutorials/your-first-detection/first-detection.mdx
+++ b/apps/documentation/tutorials/your-first-detection/first-detection.mdx
@@ -60,7 +60,7 @@ To do that, you need to create a `service_t` pointer, so that Luos engine allows
 /*******************************************************************************
  * Variables
  ******************************************************************************/
-// the new line to copy and paste
+// The new line to copy and paste:
 service_t *switcher_app; // This will be our switcher service
 ```
 
@@ -68,7 +68,7 @@ service_t *switcher_app; // This will be our switcher service
 void Switcher_Init(void)
 {
     revision_t revision = {1, 0, 0};
-    // the new line to copy and paste
+    // The new line to copy and paste:
     switcher_app = Luos_CreateService(Switcher_MsgHandler, SWITCHER_APP, "Switcher", revision);
 }
 ```
@@ -80,7 +80,7 @@ void Switcher_Init(void)
 {
     revision_t revision = {1, 0, 0};
     switcher_app = Luos_CreateService(Switcher_MsgHandler, SWITCHER_APP, "Switcher", revision);
-    // the new line to copy and paste
+    // The new line to copy and paste:
 	Luos_Detect(switcher_app);
 }
 ```
@@ -100,7 +100,7 @@ At the end of a detection, every service will receive an **END_DETECTION** messa
 ```c
 void Switcher_MsgHandler(service_t *service, const msg_t *msg)
 {
-    // the new block to copy and paste
+    // The new block to copy and paste:
     if (msg->header.cmd == END_DETECTION)
     {
         msg_t pub_msg;

--- a/apps/documentation/tutorials/your-first-detection/routing-table.mdx
+++ b/apps/documentation/tutorials/your-first-detection/routing-table.mdx
@@ -60,7 +60,7 @@ In _Switcher.c_, on the `Switcher_MsgHandler` let's find the service with the â€
  * Variables
  ******************************************************************************/
 service_t *switcher_app; // This will be our switcher service
-// the new line to copy and paste
+// The new line to copy and paste:
 uint16_t ID_Led;
 ```
 
@@ -75,24 +75,24 @@ void Switcher_MsgHandler(service_t *service, const msg_t *msg)
 {
     if (msg->header.cmd == END_DETECTION)
     {
-		// the five new lines to copy and paste
-		search_result_t filter_result;
+        // The five new lines to copy and paste:
+        search_result_t filter_result;
         RTFilter_Reset(&filter_result); // Init your filter.
-		// Now your filter_result have the entire routing table. #nofilter ;)
+        // Now your filter_result have the entire routing table. #nofilter ;)
         RTFilter_Alias(&filter_result, "led"); // Filter your filter_result only keep the services with the alias "led"
-		ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
+        ID_Led = filter_result.result_table[0]->id;//recover the first service ID with alias "led"
 
-		if (ID_Led > 0)
+        if (ID_Led > 0)
         {
-	        msg_t pub_msg;
-	        pub_msg.header.cmd = IO_STATE;
-	        pub_msg.header.target_mode = ID;
-			// the new line to copy and paste
-	        pub_msg.header.target =  ID_Led // configure the target to be our led service ID
-	        pub_msg.header.size = 1;
-	        pub_msg.data[0] = 1;
-	        Luos_SendMsg(switcher_app, &pub_msg);
-		}
+            msg_t pub_msg;
+            pub_msg.header.cmd = IO_STATE;
+            pub_msg.header.target_mode = ID;
+            // The new line to copy and paste:
+            pub_msg.header.target =  ID_Led // configure the target to be our led service ID
+            pub_msg.header.size = 1;
+            pub_msg.data[0] = 1;
+            Luos_SendMsg(switcher_app, &pub_msg);
+        }
     }
 }
 ```

--- a/apps/documentation/tutorials/your-first-message/first-message.mdx
+++ b/apps/documentation/tutorials/your-first-message/first-message.mdx
@@ -55,7 +55,7 @@ You can create your service in the button package's `Init` function, but this ti
 ```c
 void Button_Init(void)
 {
-    // the two new lines to copy and paste
+    // The two new lines to copy and paste:
     revision_t revision = {1, 0, 0};
     Luos_CreateService(0, STATE_TYPE, "button", revision);
 }
@@ -98,7 +98,7 @@ To pull messages from Luos engine, we will need to know which service is asking 
 /*******************************************************************************
  * Variable
  ******************************************************************************/
-// the new line to copy and paste
+// The new line to copy and paste:
 service_t *button_service;
 ```
 
@@ -107,9 +107,9 @@ Assign the variable to your service creation:
 ```c
 void Button_Init(void)
 {
-  // the two new lines to copy and paste
-  revision_t revision = {1, 0, 0};
-  button_service = Luos_CreateService(0, STATE_TYPE, "button", revision);
+    // The two new lines to copy and paste:
+    revision_t revision = {1, 0, 0};
+    button_service = Luos_CreateService(0, STATE_TYPE, "button", revision);
 }
 ```
 
@@ -118,12 +118,12 @@ Because we do not give any message handler to Luos engine, we will have to get t
 ```c
 void Button_Loop(void)
 {
-  // the new block to copy and paste
-  msg_t* msg;
-  if (Luos_ReadMsg(button_service, &msg) == SUCCEED)
-  {
-    // We get a message!
-  }
+    // The new block to copy and paste:
+    msg_t* msg;
+    if (Luos_ReadMsg(button_service, &msg) == SUCCEED)
+    {
+        // We get a message!
+    }
 }
 ```
 
@@ -134,15 +134,15 @@ To be able to send back the button value, we now need to check if the received m
 ```c
 void Button_Loop(void)
 {
-		msg_t* msg;
-		if (Luos_ReadMsg(button_service, &msg) == SUCCEED)
-		{
-        // the new line to copy and paste
-				if ((msg->header.cmd == IO_STATE)||(msg->header.cmd == UNKNOW)
-				{
-		      // We will have to send our button info here
-		    }
-		}
+        msg_t* msg;
+        if (Luos_ReadMsg(button_service, &msg) == SUCCEED)
+        {
+        // The new line to copy and paste:
+                if ((msg->header.cmd == IO_STATE)||(msg->header.cmd == UNKNOW)
+                {
+              // We will have to send our button info here
+            }
+        }
 }
 ```
 

--- a/apps/documentation/tutorials/your-first-message/send-message.mdx
+++ b/apps/documentation/tutorials/your-first-message/send-message.mdx
@@ -41,7 +41,7 @@ Begin by setting up the MCU pins for your button in the file _button.c_:
 /*******************************************************************************
 * Definitions
 ******************************************************************************/
-// the new line to copy and paste
+// The new line to copy and paste:
 #define BTN_PIN 8
 ```
 
@@ -53,7 +53,7 @@ void Button_Init(void)
 {
     revision_t revision = {1, 0, 0};
     button_service = Luos_CreateService(0, STATE_TYPE, "button", revision);
-    // the new line to copy and paste
+    // The new line to copy and paste:
     pinMode(BTN_PIN, INPUT);
 }
 ```
@@ -150,22 +150,22 @@ Let's fill in the information of the structure:
 ```c
 void Button_Loop(void)
 {
-	msg_t* msg;
-	while (Luos_ReadMsg(button_service, &msg) == SUCCEED)
-	{
+    msg_t* msg;
+    while (Luos_ReadMsg(button_service, &msg) == SUCCEED)
+    {
     if ((msg->header.cmd == IO_STATE)||(msg->header.cmd == UNKNOW)
     {
-      // the new block to copy and paste
-      // fill the message infos
-      msg_t pub_msg;
-      pub_msg.header.cmd         = IO_STATE;
-      pub_msg.header.target_mode = IDACK;
-      pub_msg.header.target      = msg->header.source;
-      pub_msg.header.size        = sizeof(char); // 1 byte
-      pub_msg.data[0]            = digitalRead(BTN_PIN);
-      Luos_SendMsg(service, &pub_msg);
+        // The new block to copy and paste:
+        // fill the message infos
+        msg_t pub_msg;
+        pub_msg.header.cmd         = IO_STATE;
+        pub_msg.header.target_mode = IDACK;
+        pub_msg.header.target      = msg->header.source;
+        pub_msg.header.size        = sizeof(char); // 1 byte
+        pub_msg.data[0]            = digitalRead(BTN_PIN);
+        Luos_SendMsg(service, &pub_msg);
     }
-	}
+    }
 }
 ```
 
@@ -175,22 +175,22 @@ void Button_Loop(void)
 ```c
 void Button_Loop(void)
 {
-	msg_t* msg;
-	while (Luos_ReadMsg(button_service, &msg) == SUCCEED)
-	{
+    msg_t* msg;
+    while (Luos_ReadMsg(button_service, &msg) == SUCCEED)
+    {
     if ((msg->header.cmd == IO_STATE)||(msg->header.cmd == UNKNOW)
     {
-      // the new block to copy and paste
-      // fill the message infos
-      msg_t pub_msg;
-      pub_msg.header.cmd         = IO_STATE;
-      pub_msg.header.target_mode = IDACK;
-      pub_msg.header.target      = msg->header.source;
-      pub_msg.header.size        = sizeof(char); // 1 byte
-      pub_msg.data[0]            = HAL_GPIO_ReadPin(BTN_GPIO_Port, BTN_Pin);
-      Luos_SendMsg(service, &pub_msg);
+        // The new block to copy and paste:
+        // fill the message infos
+        msg_t pub_msg;
+        pub_msg.header.cmd         = IO_STATE;
+        pub_msg.header.target_mode = IDACK;
+        pub_msg.header.target      = msg->header.source;
+        pub_msg.header.size        = sizeof(char); // 1 byte
+        pub_msg.data[0]            = HAL_GPIO_ReadPin(BTN_GPIO_Port, BTN_Pin);
+        Luos_SendMsg(service, &pub_msg);
     }
-	}
+    }
 }
 ```
 
@@ -281,7 +281,7 @@ Let's try a small exercise:
 
    ```c
    while True :
-   	device.led.state = device.button.state
+       device.led.state = device.button.state
    ```
 
 5. Run this while-loop and try to push on the button to see the LED turning on and off.

--- a/apps/documentation/tutorials/your-first-service/create-a-package.mdx
+++ b/apps/documentation/tutorials/your-first-service/create-a-package.mdx
@@ -108,12 +108,12 @@ To finish, you have to move the code you created in _Arduino.ino_ or _main.c_ di
 #include "led.h"
 #include "Arduino.h"
 
-// the new line to copy and paste
+// The new line to copy and paste:
 void Led_MsgHandler(service_t *service, const msg_t *msg);
 
 void Led_Init(void)
 {
-    // the three new lines to copy and paste
+    // The three new lines to copy and paste:
     pinMode(LED_BUILTIN, OUTPUT);
     revision_t revision = {1, 0, 0};
     Luos_CreateService(Led_MsgHandler, STATE_TYPE, "led", revision);
@@ -124,7 +124,7 @@ void Led_Loop(void)
  // Nothing to do here in the case of the lED because everything is made on event on Led_MsgHandler.
 }
 
-// the new block to copy and paste
+// The new block to copy and paste:
 void Led_MsgHandler(service_t *service, const msg_t *msg)
 {
     if (msg->header.cmd == IO_STATE)
@@ -148,19 +148,19 @@ void Led_MsgHandler(service_t *service, const msg_t *msg)
 #include "led.h"
 #include "gpio.h"
 
-// the new line to copy and paste
+// The new line to copy and paste:
 static void Led_MsgHandler(service_t *service, const msg_t *msg);
 
 void Led_Init(void)
 {
-    // the two new lines to copy and paste
+    // The two new lines to copy and paste:
     revision_t revision = {1, 0, 0};
     Luos_CreateService(Led_MsgHandler, STATE_TYPE, "led", revision);
 }
 
 void Led_Loop(void) {}
 
-// the new block to copy and paste
+// The new block to copy and paste:
 static void Led_MsgHandler(service_t *service, const msg_t *msg)
 {
     if (msg->header.cmd == IO_STATE)
@@ -193,11 +193,13 @@ extern "C"
 {
 #endif
 
-#include <luos_engine.h>
+#include "luos_engine.h"
+#include "robus_network.h"
 #include "blinker.h"
 #include "pipe.h"
 #include "gate.h"
-// the new line to copy and paste
+
+// The new line to copy and paste:
 #include "led.h"
 
 #ifdef __cplusplus
@@ -207,20 +209,24 @@ extern "C"
 void setup()
 {
     Luos_Init();
+    Robus_Init();
     Pipe_Init();
     Gate_Init();
     Blinker_Init();
-    // the new line to copy and paste
-	Led_Init();
+
+    // The new line to copy and paste:
+    Led_Init();
 }
 
 void loop()
 {
     Luos_Loop();
+    Robus_Loop();
     Pipe_Loop();
     Gate_Loop();
     Blinker_Loop();
-    // the new line to copy and paste
+
+    // The new line to copy and paste:
     Led_Loop();
 }
 ```
@@ -229,11 +235,13 @@ void loop()
 <TabItem value="Nucleo" label="Nucleo">
 
 ```c
-#include <luos_engine.h>
+#include "luos_engine.h"
+#include "robus_network.h"
 #include "blinker.h"
 #include "pipe.h"
 #include "gate.h"
-// the new line to copy and paste
+
+// The new line to copy and paste:
 #include "led.h"
 
 void SystemClock_Config(void);
@@ -245,19 +253,23 @@ int main(void)
     MX_GPIO_Init();
 
     Luos_Init();
+    Robus_Init();
     Pipe_Init();
     Gate_Init();
     Blinker_Init();
-    // the new line to copy and paste
+
+    // The new line to copy and paste:
     Led_Init();
 
     while (1)
     {
         Luos_Loop();
+        Robus_Loop();
         Pipe_Loop();
         Gate_Loop();
         Blinker_Loop();
-        // the new line to copy and paste
+
+        // The new line to copy and paste:
         Led_Loop();
     }
 }

--- a/apps/documentation/tutorials/your-first-service/first-service.mdx
+++ b/apps/documentation/tutorials/your-first-service/first-service.mdx
@@ -65,7 +65,8 @@ Throughout this tutorial, you will have to locate the right lines where to copy/
 
 ```c
 // the code to locate:
-#include <luos_engine.h>
+#include "luos_engine.h"
+#include "robus_network.h"
 #include "blinker.h"
 #include "pipe.h"
 #include "gate.h"
@@ -90,12 +91,13 @@ Now that we have everything we need to create our service, we will begin by crea
 void setup()
 {
     Luos_Init();
+    Robus_Init();
     Pipe_Init();
     Gate_Init();
     Blinker_Init();
 
-    // the two new lines to copy and paste:
-	revision_t revision = {1, 0, 0};
+    // The two new lines to copy and paste:
+    revision_t revision = {1, 0, 0};
     Luos_CreateService(Led_MsgHandler, STATE_TYPE, "led", revision);
 
 }
@@ -112,17 +114,19 @@ int main(void)
     MX_GPIO_Init();
 
     Luos_Init();
+    Robus_Init();
     Pipe_Init();
     Gate_Init();
     Blinker_Init();
 
-    // the two new lines to copy and paste:
-	revision_t revision = {1, 0, 0};
+    // The two new lines to copy and paste:
+    revision_t revision = {1, 0, 0};
     Luos_CreateService(Led_MsgHandler, STATE_TYPE, "led", revision);
 
     while (1)
     {
         Luos_Loop();
+        Robus_Loop();
         Pipe_Loop();
         Gate_Loop();
         Blinker_Loop();
@@ -174,6 +178,7 @@ Add your PIN configuration next to the service initialization in the same file:
 void setup()
 {
     Luos_Init();
+    Robus_Init();
     Pipe_Init();
     Gate_Init();
     Blinker_Init();
@@ -181,7 +186,7 @@ void setup()
     revision_t revision = {1, 0, 0};
     Luos_CreateService(Led_MsgHandler, STATE_TYPE, "led", revision);
 
-    // the new line to copy and paste:
+    // The new line to copy and paste:
     pinMode(LED_BUILTIN, OUTPUT);
 
 }
@@ -196,10 +201,11 @@ int main(void)
     HAL_Init();
     SystemClock_Config();
 
-    // the new line to copy and paste:
+    // The new line to copy and paste:
     MX_GPIO_Init();//Nucleo Led Pin init
 
     Luos_Init();
+    Robus_Init();
     Pipe_Init();
     Gate_Init();
     Blinker_Init();
@@ -209,6 +215,7 @@ int main(void)
     while (1)
     {
         Luos_Loop();
+        Robus_Loop();
         Pipe_Loop();
         Gate_Loop();
         Blinker_Loop();
@@ -235,15 +242,15 @@ To control the LED depending on the message data, you can fill the content of th
 ```c
 void Led_MsgHandler(service_t *service, const msg_t *msg)
 {
-     // the block to copy and paste:
-      if (msg->data[0] == 0)
-      {
-          digitalWrite(LED_BUILTIN, false);
-      }
-      else
-      {
-          digitalWrite(LED_BUILTIN, true);
-      }
+    // the block to copy and paste:
+    if (msg->data[0] == 0)
+    {
+        digitalWrite(LED_BUILTIN, false);
+    }
+    else
+    {
+        digitalWrite(LED_BUILTIN, true);
+    }
 }
 ```
 
@@ -317,17 +324,17 @@ void Led_MsgHandler(service_t *service, const msg_t *msg)
 void Led_MsgHandler(service_t *service, const msg_t *msg)
 {
     // the new line to copy and paste:
-	if (msg->header.cmd == IO_STATE)
+    if (msg->header.cmd == IO_STATE)
     {
-		    if (msg->data[0] == false)
-		    {
-		        HAL_GPIO_WritePin(LED_GPIO_Port, LED_Pin, false);
-		    }
-		    else
-		    {
-		        HAL_GPIO_WritePin(LED_GPIO_Port, LED_Pin, true);
-		    }
-		}
+            if (msg->data[0] == false)
+            {
+                HAL_GPIO_WritePin(LED_GPIO_Port, LED_Pin, false);
+            }
+            else
+            {
+                HAL_GPIO_WritePin(LED_GPIO_Port, LED_Pin, true);
+            }
+        }
 }
 ```
 


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [x] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
